### PR TITLE
Adds response headers to coach.handler.finish

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coach (0.2.0)
+    coach (0.2.1)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
 
@@ -101,4 +101,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.3
+   1.10.4

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -25,7 +25,8 @@ module Coach
 
       finish = Time.now
       publish('coach.handler.finish',
-              start, finish, nil, start_event.merge(response: { status: response[0] }))
+              start, finish, nil,
+              start_event.merge(response: { status: response[0], headers: response[1] }))
 
       response
     end

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
The coach.handler.finish event already includes a field for the request
response. This commit adds a `headers` value to that field which will
give logging subscribers access to the response headers, should they
choose to use them.

@petehamilton could you review?