### PR TITLE
Allows logging of metadata with coach notifications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coach (0.2.0)
+    coach (0.2.1)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
 
@@ -101,4 +101,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.3
+   1.10.4

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -25,7 +25,10 @@ module Coach
 
       finish = Time.now
       publish('coach.handler.finish',
-              start, finish, nil, start_event.merge(response: { status: response[0] }))
+              start, finish, nil,
+              start_event.merge(
+                response: { status: response[0] },
+                metadata: context.fetch(:_metadata, {})))
 
       response
     end

--- a/lib/coach/middleware.rb
+++ b/lib/coach/middleware.rb
@@ -15,6 +15,10 @@ module Coach
     end
 
     def self.provides(*new_provided)
+      if new_provided.include?(:_metadata)
+        raise 'Cannot provide :_metadata, Coach uses this internally!'
+      end
+
       provided.concat(new_provided)
       provided.uniq!
     end
@@ -74,6 +78,12 @@ module Coach
         ActiveSupport::Notifications.
           instrument('coach.middleware.finish', middleware_event) { call }
       end
+    end
+
+    # Adds key-values to metadata, to be published with coach events.
+    def log_metadata(**values)
+      @_context[:_metadata] ||= {}
+      @_context[:_metadata].merge!(values)
     end
 
     # Helper to access request params from within middleware

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -78,10 +78,12 @@ module Coach
       broadcast(event, benchmark)
     end
 
+    # Receives a handler.finish event, with processed benchmark. Publishes to
+    # coach.request notification.
     def broadcast(event, benchmark)
       serialized = RequestSerializer.new(event[:request]).serialize.
         merge(benchmark.stats).
-        merge(event.slice(:response))
+        merge(event.slice(:response, :metadata))
       ActiveSupport::Notifications.publish('coach.request', serialized)
     end
   end

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/lib/spec/matchers.rb
+++ b/lib/spec/matchers.rb
@@ -12,6 +12,7 @@ def build_middleware(name)
 
     def call
       config[:callback].call if config.include?(:callback)
+      log_metadata(Hash[name.to_sym, true])
 
       # Build up a list of middleware called, in the order they were called
       if next_middleware

--- a/spec/lib/coach/middleware_spec.rb
+++ b/spec/lib/coach/middleware_spec.rb
@@ -5,6 +5,13 @@ describe Coach::Middleware do
   let(:context_) { {} }
   let(:middleware_obj) { middleware_class.new(context_, nil) }
 
+  describe ".provides" do
+    it "blows up if providing a reserved keyword" do
+      expect { middleware_class.provides(:_metadata) }.
+        to raise_exception(/cannot provide.* coach uses this/i)
+    end
+  end
+
   describe ".provides?" do
     context "given names it does provide" do
       before { middleware_class.provides(:foo, :bar) }

--- a/spec/lib/coach/notifications_spec.rb
+++ b/spec/lib/coach/notifications_spec.rb
@@ -48,10 +48,18 @@ describe Coach::Notifications do
       expect(middleware_event).not_to be_nil
     end
 
-    it "broadcasts event containing all middleware that have been run" do
-      handler.call({})
-      middleware_names = middleware_event[:chain].map { |item| item[:name] }
-      expect(middleware_names).to include(*%w(Terminal A B))
+    describe "coach.request event" do
+      before { handler.call({}) }
+
+      it "contains all middleware that have been run" do
+        middleware_names = middleware_event[:chain].map { |item| item[:name] }
+        expect(middleware_names).to include(*%w(Terminal A B))
+      end
+
+      it "includes all logged metadata" do
+        expect(middleware_event).
+          to include(metadata: { A: true, B: true, Terminal: true })
+      end
     end
   end
 


### PR DESCRIPTION
Tagging logs with metadata should be something you can do along the
middleware chain. This commit implements a `log_metadata` method on all
middlewares that allows logging of arbitrary metadata, which is then
sent with all `coach.handler.finish` and `coach.request` events.

Different angle than before, @petehamilton @timrogers what're your thoughts?