### PR TITLE
Implements diagramatic errors of missing requirements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coach (0.2.1)
+    coach (0.2.2)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
 
@@ -101,4 +101,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.4
+   1.10.5

--- a/lib/coach/errors.rb
+++ b/lib/coach/errors.rb
@@ -1,9 +1,22 @@
 module Coach
   module Errors
     class MiddlewareDependencyNotMet < StandardError
-      def initialize(middleware, keys)
-        super("#{middleware.name} requires keys [#{keys.join(',')}] that are not " \
-              "provided by the middleware chain")
+      def initialize(middleware, previous_chain, missing_keys)
+        @middleware = middleware
+        @previous_chain = previous_chain
+        @missing_keys = missing_keys
+
+        super("\n\n#{chain_diagram}\n\n#{missing_keys_message}\n\n")
+      end
+
+      def missing_keys_message
+        "  #{@middleware.name} is missing #{@missing_keys} from above!"
+      end
+
+      def chain_diagram
+        @previous_chain.map do |middleware|
+          "  #{middleware.name} => #{middleware.provided}"
+        end.join("\n")
       end
     end
 

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -5,6 +5,10 @@ module Coach
     def initialize(middleware)
       @root_item = MiddlewareItem.new(middleware)
       validate!
+    rescue Coach::Errors::MiddlewareDependencyNotMet => error
+      # Remove noise of validation stack trace, reset to the handler callsite
+      error.backtrace.clear.push(*Thread.current.backtrace)
+      raise error
     end
 
     # Run validation on the root of the middleware chain

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/lib/coach/middleware_validator_spec.rb
+++ b/spec/lib/coach/middleware_validator_spec.rb
@@ -56,7 +56,7 @@ describe Coach::MiddlewareValidator do
       context "at terminal" do
         before { head_middleware.requires :a, :c }
 
-        it { is_expected.to raise_exception(/requires keys \[a,c\]/) }
+        it { is_expected.to raise_exception(/missing \[:a, :c\]/) }
       end
 
       context "from unordered middleware" do
@@ -65,7 +65,7 @@ describe Coach::MiddlewareValidator do
           middleware_b.provides :b
         end
 
-        it { is_expected.to raise_exception(/requires keys \[b\]/) }
+        it { is_expected.to raise_exception(/missing \[:b\]/) }
       end
     end
   end


### PR DESCRIPTION
Had some issues earlier debugging the trace provided by Coach if a middleware key is missing. This PR attempts to solve that by including a trace of the middleware in the output of the error message. Not spec'd yet as I wanted to get some feedback on whether this is useful.

@greysteil @isaacseymour @petehamilton, opinions?

![screenshot 2015-07-17 15 55 47](https://cloud.githubusercontent.com/assets/3518874/8750023/feee4e82-2c9c-11e5-8f1d-ed9a210f284d.png)
