### PR TITLE
Inheriting config values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,27 @@
 PATH
   remote: .
   specs:
-    coach (0.2.2)
+    coach (0.2.3)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.1)
-      actionview (= 4.2.1)
-      activesupport (= 4.2.1)
+    actionpack (4.2.3)
+      actionview (= 4.2.3)
+      activesupport (= 4.2.3)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    actionview (4.2.1)
-      activesupport (= 4.2.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.3)
+      activesupport (= 4.2.3)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.1)
-    activesupport (4.2.1)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activesupport (4.2.3)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -36,11 +36,11 @@ GEM
     erubis (2.7.0)
     i18n (0.7.0)
     json (1.8.3)
-    loofah (2.0.2)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)
     mini_portile (0.6.2)
-    minitest (5.7.0)
+    minitest (5.8.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     parser (2.2.2.5)
@@ -50,12 +50,12 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.1)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.6)
+    rails-dom-testing (1.0.7)
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
@@ -101,4 +101,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -142,6 +142,34 @@ running code before hitting controller methods. It allows you to be confident th
 data you require has been loaded, and makes tracing the origin of that data as simple as
 looking up the chain.
 
+## Configuring middlewares
+
+By making use of middleware config hashes, you can build generalised middlewares that can
+be configured specifically for the chain that they are used in.
+
+```ruby
+class Logger < Coach::Middleware
+  def call
+    # Logs the incoming request path, with a configured prefix
+    Rails.logger.info("[#{config[:prefix]}] - #{request.path}")
+  end
+end
+
+class HelloUser < Coach::Middleware
+  uses Logger, prefix: 'HelloUser'
+  uses Authentication
+
+  def call
+    ...
+  end
+end
+```
+
+The above configures a `Logger` middleware to prefix it's log entries with `'HelloUser'`.
+This is a contrived example, but at GoCardless we've created middlewares that can act as
+generalised resource endpoints (show, index, etc) when given the model class and some
+extra configuration.
+
 ## Testing
 
 The basic strategy is to test each middleware in isolation, covering all the edge cases,

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -40,11 +40,11 @@ module Coach
     # Traverse the middlware tree to build a linear middleware sequence,
     # containing only middlewares that apply to this request.
     def build_sequence(item, context)
-      sequence = item.middleware.middleware_dependencies.flat_map do |child_item|
-        build_sequence(child_item, context)
+      sequence = item.middleware.middleware_dependencies.map do |child_item|
+        build_sequence(child_item.set_parent(item), context)
       end
 
-      dedup_sequence(sequence + [item])
+      dedup_sequence([*sequence, item].flatten)
     end
 
     # Given a middleware sequence, filter out items not applicable to the

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -40,21 +40,18 @@ module Coach
     # Traverse the middlware tree to build a linear middleware sequence,
     # containing only middlewares that apply to this request.
     def build_sequence(item, context)
-      sub_sequence = item.middleware.middleware_dependencies
-      filtered_sub_sequence = filter_sequence(sub_sequence, context)
-      flattened_sub_sequence = filtered_sub_sequence.flat_map do |child_item|
+      sequence = item.middleware.middleware_dependencies.flat_map do |child_item|
         build_sequence(child_item, context)
       end
 
-      dedup_sequence(flattened_sub_sequence + [item])
+      dedup_sequence(sequence + [item])
     end
 
     # Given a middleware sequence, filter out items not applicable to the
     # current request, and set up a chain of instantiated middleware objects,
     # ready to serve a request.
     def build_request_chain(sequence, context)
-      chain_items = filter_sequence(sequence, context)
-      chain_items.reverse.reduce(nil) do |successor, item|
+      sequence.reverse.reduce(nil) do |successor, item|
         item.build_middleware(context, successor)
       end
     end
@@ -70,12 +67,6 @@ module Coach
     # config, leaving only the first instance
     def dedup_sequence(sequence)
       sequence.uniq { |item| [item.class, item.middleware, item.config] }
-    end
-
-    # Filter out middleware items that don't apply to this request - i.e. those
-    # that have defined an `if` condition that doesn't match this context.
-    def filter_sequence(sequence, context)
-      sequence.select { |item| item.use_with_context?(context) }
     end
 
     # Event to send for start of handler

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end

--- a/lib/spec/matchers.rb
+++ b/lib/spec/matchers.rb
@@ -16,7 +16,7 @@ def build_middleware(name)
 
       # Build up a list of middleware called, in the order they were called
       if next_middleware
-        [name].concat(next_middleware.call)
+        [name + config.except(:callback).inspect.to_s].concat(next_middleware.call)
       else
         [name]
       end

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -25,7 +25,7 @@ describe Coach::Handler do
       result = handler.call({})
       expect(a_spy).to have_received(:call)
       expect(b_spy).to have_received(:call)
-      expect(result).to eq(%w(A B Terminal))
+      expect(result).to eq(%w(A{} B{} Terminal))
     end
   end
 
@@ -79,27 +79,30 @@ describe Coach::Handler do
 
   describe "#build_request_chain" do
     before { terminal_middleware.uses(middleware_a) }
-    before { terminal_middleware.uses(middleware_b, if: ->(ctx) { false }) }
-    before { terminal_middleware.uses(middleware_c) }
+    before { terminal_middleware.uses(middleware_b, b: true) }
 
     let(:root_item) { Coach::MiddlewareItem.new(terminal_middleware) }
     let(:sequence) { handler.build_sequence(root_item, {}) }
 
     it "instantiates all matching middleware items in the sequence" do
       expect(middleware_a).to receive(:new)
-      expect(middleware_c).to receive(:new)
+      expect(middleware_b).to receive(:new)
       expect(terminal_middleware).to receive(:new)
-      handler.build_request_chain(sequence, {})
-    end
-
-    it "doesn't instantiate non-matching middleware items" do
-      expect(middleware_b).not_to receive(:new)
       handler.build_request_chain(sequence, {})
     end
 
     it "sets up the chain correctly, calling each item in the correct order" do
       expect(handler.build_request_chain(sequence, {}).call).
-        to eq(%w(A C Terminal))
+        to eq(%w(A{} B{:b=>true} Terminal))
+    end
+
+    context "with inheriting config" do
+      before { middleware_b.uses(middleware_c, ->(config) { config.slice(:b) }) }
+
+      it "calls lambda with parent middlewares config" do
+        expect(handler.build_request_chain(sequence, {}).call).
+          to eq(%w(A{} C{:b=>true} B{:b=>true} Terminal))
+      end
     end
   end
 

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -8,6 +8,7 @@ describe Coach::Handler do
   let(:middleware_a) { build_middleware("A") }
   let(:middleware_b) { build_middleware("B") }
   let(:middleware_c) { build_middleware("C") }
+  let(:middleware_d) { build_middleware("D") }
 
   let(:terminal_middleware) { build_middleware("Terminal") }
   let(:handler) { Coach::Handler.new(terminal_middleware) }
@@ -98,10 +99,11 @@ describe Coach::Handler do
 
     context "with inheriting config" do
       before { middleware_b.uses(middleware_c, ->(config) { config.slice(:b) }) }
+      before { middleware_b.uses(middleware_d) }
 
       it "calls lambda with parent middlewares config" do
         expect(handler.build_request_chain(sequence, {}).call).
-          to eq(%w(A{} C{:b=>true} B{:b=>true} Terminal))
+          to eq(%w(A{} C{:b=>true} D{} B{:b=>true} Terminal))
       end
     end
   end


### PR DESCRIPTION
Heard a few people recently saying how verbose they thing the coach boilerplate code is for PS. Have looked into the issue and really we needed some way to pass config values down the chain in order to bundle our middlewares more sensibly.

I've added the behaviour that whenever you pass a lambda as a config value to a middleware `uses` call, then when the chain is built that lambda is called with the parent middleware's config hash to calculate what the config value should be for the next middleware.

It's spec'd out [here](https://github.com/gocardless/coach/blob/allow-config-inheritance/spec/lib/coach/handler_spec.rb#L99-L106) but as an example...

```ruby
module Routes::Payments
  class Index < Coach::Middleware
    uses Middleware::Actions::Index,
	 validator: PaymentsControllerFilterValidator
  end
end

module Middleware::Actions
  class Index < Coach::Middleware
    uses Middleware::CheckQueryParams, ->(config) { config.slice(:validator)}
    def call
      ...
    end
  end
end
```

This will allow us to group our middlewares while passing config multiple levels down. Fetches can be used to throw errors for missing keys.

@isaacseymour can you have a look at this? Also @jackfranklin, @english 