### PR TITLE
Allow Handler to take a config hash, just like Middleware

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coach (0.2.3)
+    coach (0.3.0)
       actionpack (~> 4.2)
       activesupport (~> 4.2)
 

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -2,8 +2,8 @@ require "coach/errors"
 
 module Coach
   class Handler
-    def initialize(middleware)
-      @root_item = MiddlewareItem.new(middleware)
+    def initialize(middleware, config = {})
+      @root_item = MiddlewareItem.new(middleware, config)
       validate!
     rescue Coach::Errors::MiddlewareDependencyNotMet => error
       # Remove noise of validation stack trace, reset to the handler callsite

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.2.3'
+  VERSION = '0.3.0'
 end

--- a/lib/spec/matchers.rb
+++ b/lib/spec/matchers.rb
@@ -14,11 +14,13 @@ def build_middleware(name)
       config[:callback].call if config.include?(:callback)
       log_metadata(Hash[name.to_sym, true])
 
+      response = [name + config.except(:callback).inspect.to_s]
+
       # Build up a list of middleware called, in the order they were called
       if next_middleware
-        [name + config.except(:callback).inspect.to_s].concat(next_middleware.call)
+        response.concat(next_middleware.call)
       else
-        [name]
+        response
       end
     end
   end


### PR DESCRIPTION
Very convenient for testing since it allows for dependency injection like:

```ruby
class UsersIndex < Coach::Handler
  def call
    db_connection = config.fetch(:db_connection)
    users = db_connection.run("SELECT * from users")

    [200, {}, [users.to_json]]
  end
end

db = Database.connect

router.draw do
  match "/users", to: Coach::Handler.new(UsersIndex, db_connection: db), via: :get
end
```

@lawrencejones @hmarr what do you think?