### PR TITLE
Make Router accept a Mapper rather than a Rails app

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,20 +224,22 @@ end
 ## Routing
 
 For routes that represent resource actions, Coach provides some syntactic sugar to
-allow concise mapping of endpoint to handler.
+allow concise mapping of endpoint to handler in Rails apps.
 
 ```ruby
-router = Coach::Router.new(Example::Application)
-
-router.draw(Routes::Users,
-            base: "/users",
-            actions: [
-              :index,
-              :show,
-              :create,
-              :update,
-              disable: { method: :post, url: "/:id/actions/disable" }
-            ])
+# config/routes.rb
+Example::Application.routes.draw do
+  router = Coach::Router.new(self)
+  router.draw(Routes::Users,
+              base: "/users",
+              actions: [
+                :index,
+                :show,
+                :create,
+                :update,
+                disable: { method: :post, url: "/:id/actions/disable" }
+              ])
+end
 ```
 
 Default actions that conform to standard REST principles can be easily loaded, with the

--- a/lib/coach/router.rb
+++ b/lib/coach/router.rb
@@ -11,8 +11,8 @@ module Coach
       destroy: { method: :delete, url: ':id' }
     }.each_value(&:freeze).freeze
 
-    def initialize(app)
-      @app = app
+    def initialize(mapper)
+      @mapper = mapper
     end
 
     def draw(routes, base: nil, as: nil, constraints: nil, actions: [])
@@ -27,9 +27,7 @@ module Coach
     end
 
     def match(url, **args)
-      @app.routes.draw do
-        match url, args
-      end
+      @mapper.match(url, args)
     end
 
     private

--- a/spec/lib/coach/router_spec.rb
+++ b/spec/lib/coach/router_spec.rb
@@ -4,8 +4,8 @@ require 'coach/router'
 require 'coach/handler'
 
 describe Coach::Router do
-  subject(:router) { described_class.new(app) }
-  let(:app) { double(:rails_app, routes: double(draw: nil)) }
+  subject(:router) { described_class.new(mapper) }
+  let(:mapper) { double(:mapper) }
 
   before do
     allow(Coach::Handler).to receive(:new) { |route| route }
@@ -26,12 +26,12 @@ describe Coach::Router do
     let(:actions) { [action] }
 
     it "correctly mounts url for :#{action}" do
-      expect(router).to receive(:match).with(params[:url], anything)
+      expect(mapper).to receive(:match).with(params[:url], anything)
       draw
     end
 
     it "correctly mounts on method for :#{action}" do
-      expect(router).to receive(:match).
+      expect(mapper).to receive(:match).
         with(anything, hash_including(via: params[:method]))
       draw
     end
@@ -54,7 +54,7 @@ describe Coach::Router do
       context "with no slash" do
         let(:custom_url) { ':id/refund' }
         it "mounts correct url" do
-          expect(router).to receive(:match).with('/resource/:id/refund', anything)
+          expect(mapper).to receive(:match).with('/resource/:id/refund', anything)
           draw
         end
       end
@@ -62,7 +62,7 @@ describe Coach::Router do
       context "with multiple /'s" do
         let(:custom_url) { '//:id/refund' }
         it "mounts correct url" do
-          expect(router).to receive(:match).with('/resource/:id/refund', anything)
+          expect(mapper).to receive(:match).with('/resource/:id/refund', anything)
           draw
         end
       end


### PR DESCRIPTION
When you're inside the `routes.draw` call in a Rails app, `self` is an instance of `ActionDispatch::Routing::Mapper`. Accepting the Mapper directly lets us pass `self` in `config/routes.rb`, which means that the routes obey surrounding context (e.g. when wrapped in a `scope do ... end`) block.

This does make it slightly harder to use if you want to pass a Rails Application directly, but I'm not sure why you'd want to do that. If there is a legit reason, it'd be pretty trivial to add an alternative constructor.

@lawrencejones thoughts?