### PR TITLE
Remove dependency on rails for RSpec matchers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,7 +111,7 @@ Style/PredicateName:
 Style/RedundantSelf:
   Enabled: false
 
-Style/SingleSpaceBeforeFirstArg:
+Style/Style/SpaceBeforeFirstArg:
   Enabled: false
 
 # Configuration parameters: MultiSpaceAllowedForOperators.

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -82,8 +82,8 @@ module Coach
     # coach.request notification.
     def broadcast(event, benchmark)
       serialized = RequestSerializer.new(event[:request]).serialize.
-        merge(benchmark.stats).
-        merge(event.slice(:response, :metadata))
+                   merge(benchmark.stats).
+                   merge(event.slice(:response, :metadata))
       ActiveSupport::Notifications.publish('coach.request', serialized)
     end
   end

--- a/lib/coach/request_benchmark.rb
+++ b/lib/coach/request_benchmark.rb
@@ -15,7 +15,7 @@ module Coach
       event = { name: name, start: start, finish: finish }
 
       duration_of_children = child_events_for(event).
-        inject(0) { |total, e| total + e[:duration] }
+                             inject(0) { |total, e| total + e[:duration] }
       event[:duration] = (finish - start) - duration_of_children
 
       @events.push(event)

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.4.0'
+  VERSION = '0.4.0'.freeze
 end

--- a/lib/spec/matchers.rb
+++ b/lib/spec/matchers.rb
@@ -47,7 +47,7 @@ end
 
 RSpec::Matchers.define :respond_with_body_that_matches do |body_regex|
   match do |middleware|
-    @response_body = middleware.call.third.join
+    @response_body = middleware.call[2].join
     @response_body.match(body_regex)
   end
 
@@ -58,7 +58,7 @@ end
 
 RSpec::Matchers.define :respond_with_envelope do |envelope, keys = []|
   match do |middleware|
-    @response = JSON.parse(middleware.call.third.join)
+    @response = JSON.parse(middleware.call[2].join)
     expect(@response).to include(envelope.to_s)
 
     @envelope = @response[envelope.to_s].with_indifferent_access


### PR DESCRIPTION
The rspec matchers currently depend on `third` which is only found in
Rails (http://api.rubyonrails.org/classes/Array.html#method-i-third),
not ruby.

This commit moves us to use array access at index 2 instead `x[2]`,
which is compatible with plain 'ol ruby.