### PR TITLE
Update Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,7 +111,7 @@ Style/PredicateName:
 Style/RedundantSelf:
   Enabled: false
 
-Style/SingleSpaceBeforeFirstArg:
+Style/Style/SpaceBeforeFirstArg:
   Enabled: false
 
 # Configuration parameters: MultiSpaceAllowedForOperators.

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -82,8 +82,8 @@ module Coach
     # coach.request notification.
     def broadcast(event, benchmark)
       serialized = RequestSerializer.new(event[:request]).serialize.
-        merge(benchmark.stats).
-        merge(event.slice(:response, :metadata))
+                   merge(benchmark.stats).
+                   merge(event.slice(:response, :metadata))
       ActiveSupport::Notifications.publish('coach.request', serialized)
     end
   end

--- a/lib/coach/request_benchmark.rb
+++ b/lib/coach/request_benchmark.rb
@@ -15,7 +15,7 @@ module Coach
       event = { name: name, start: start, finish: finish }
 
       duration_of_children = child_events_for(event).
-        inject(0) { |total, e| total + e[:duration] }
+                             inject(0) { |total, e| total + e[:duration] }
       event[:duration] = (finish - start) - duration_of_children
 
       @events.push(event)

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.4.0'
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
Stale rubocop config is causing https://github.com/gocardless/coach/pull/10 to fail.

Will merge in once specs pass.

@greysteil FYI