### PR TITLE
Tests Coach::RequestSerializer instances

### DIFF
--- a/spec/lib/coach/request_serializer_spec.rb
+++ b/spec/lib/coach/request_serializer_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
+require 'active_support/core_ext/object/try'
 require 'coach/request_serializer'
 
 describe Coach::RequestSerializer do
-  describe '.apply_header_rule' do
+  describe ".apply_header_rule" do
     before { described_class.clear_header_rules! }
 
     let(:header) { 'http_abc' }
@@ -32,6 +33,39 @@ describe Coach::RequestSerializer do
       it "does not modify value" do
         sanitized = Coach::RequestSerializer.apply_header_rule(header, 'value')
         expect(sanitized).to eq('value')
+      end
+    end
+
+    context "as an instance" do
+      let(:mock_request) do
+        instance_double("ActionDispatch::Request", format:              nil,
+                                                   remote_ip:           nil,
+                                                   uuid:                nil,
+                                                   method:              nil,
+                                                   filtered_parameters: nil,
+                                                   filtered_env:        {
+                                                     "foo" => "bar",
+                                                     "HTTP_foo" => "bar"
+                                                   })
+      end
+
+      subject(:request_serializer) { described_class.new(mock_request) }
+
+      describe "#serialize" do
+        subject(:serialized) { request_serializer.serialize }
+
+        it "rescues any exceptions request#fullpath may raise" do
+          allow(mock_request).to receive(:fullpath).and_raise
+
+          expect(serialized[:path]).to eq('unknown')
+        end
+
+        it "filters headers allowing only those prefixed with 'HTTP_'" do
+          allow(mock_request).to receive(:fullpath).and_return(nil)
+
+          expect(serialized[:headers]).not_to include("foo")
+          expect(serialized[:headers]).to include("http_foo")
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a few specs for Coach::RequestSerializer instances.

These specs should gain us 100% coverage for this class.