### PR TITLE
Cleans up Coach::Handler#inspect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,7 +111,7 @@ Style/PredicateName:
 Style/RedundantSelf:
   Enabled: false
 
-Style/Style/SpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 # Configuration parameters: MultiSpaceAllowedForOperators.

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -7,7 +7,7 @@ module Coach
       validate!
     rescue Coach::Errors::MiddlewareDependencyNotMet => error
       # Remove noise of validation stack trace, reset to the handler callsite
-      error.backtrace.clear.push(*Thread.current.backtrace)
+      error.backtrace.clear.concat(Thread.current.backtrace)
       raise error
     end
 
@@ -30,9 +30,9 @@ module Coach
       finish = Time.now
       publish('coach.handler.finish',
               start, finish, nil,
-              start_event.merge(
-                response: { status: response[0] },
-                metadata: context.fetch(:_metadata, {})))
+              start_event.
+                merge(response: { status: response[0] },
+                      metadata: context.fetch(:_metadata, {})))
 
       response
     end
@@ -54,6 +54,10 @@ module Coach
       sequence.reverse.reduce(nil) do |successor, item|
         item.build_middleware(context, successor)
       end
+    end
+
+    def inspect
+      "#<Coach::Handler[#{@root_item.middleware.name}]>"
     end
 
     private

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3'.freeze
 end

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -11,7 +11,7 @@ describe Coach::Handler do
   let(:middleware_d) { build_middleware("D") }
 
   let(:terminal_middleware) { build_middleware("Terminal") }
-  let(:handler) { Coach::Handler.new(terminal_middleware, handler: true) }
+  subject(:handler) { Coach::Handler.new(terminal_middleware, handler: true) }
 
   before { Coach::Notifications.unsubscribe! }
 
@@ -138,5 +138,9 @@ describe Coach::Handler do
       it { is_expected.to include('coach.middleware.finish') }
       it { is_expected.to include('coach.handler.finish') }
     end
+  end
+
+  describe "#inspect" do
+    its(:inspect) { is_expected.to eql('#<Coach::Handler[Terminal]>') }
   end
 end


### PR DESCRIPTION
When running `rake routes` on a large Rails app that uses Coach, the default
inspect method makes the output very difficult to read. This commit simplifies
the inspect method to indicate that the object is an instance of
`Coach::Handler` and includes the name of the root middleware.

Example...
```
    handler.inspect == '#<Coach::Handler[Routes::Novelty::JacketRequest]>'
```