### PR TITLE
Fix middleware lookup issue in router

### DIFF
--- a/lib/coach/router.rb
+++ b/lib/coach/router.rb
@@ -17,7 +17,10 @@ module Coach
 
     def draw(routes, base: nil, as: nil, constraints: nil, actions: [])
       action_traits(actions).each do |action, traits|
-        route = routes.const_get(camel(action))
+        # Passing false to const_get prevents it searching ancestors until a
+        # match is found. Without this, globally defined constants such as
+        # `Process` will be picked up before consts that need to be autoloaded.
+        route = routes.const_get(camel(action), false)
         match(action_url(base, traits),
               to: Handler.new(route),
               via: traits[:method],

--- a/spec/lib/coach/router_spec.rb
+++ b/spec/lib/coach/router_spec.rb
@@ -12,14 +12,11 @@ describe Coach::Router do
   end
 
   let(:resource_routes) do
-    Module.new do
-      class Index; end
-      class Show; end
-      class Create; end
-      class Update; end
-      class Destroy; end
-      class Refund; end # custom
+    routes_module = Module.new
+    [:Index, :Show, :Create, :Update, :Destroy, :Refund].each do |class_name|
+      routes_module.const_set(class_name, Class.new)
     end
+    routes_module
   end
 
   shared_examples "mount action" do |action, params|
@@ -72,6 +69,14 @@ describe Coach::Router do
       let(:actions) { [:unknown] }
       it "raises RouterUnknownDefaultAction" do
         expect { draw }.to raise_error(Coach::Errors::RouterUnknownDefaultAction)
+      end
+    end
+
+    context "with unknown action that clashes with a global constant name" do
+      let(:actions) { [process: { method: :post, url: ":id/process" }] }
+
+      it "raises NameError" do
+        expect { draw }.to raise_error(NameError)
       end
     end
   end


### PR DESCRIPTION
Previously, the router would pick up globally-defined constants
that matched names of Coach middleware, rather than triggering
`const_missing` (which is how autoloading works)

The router tests also had to be modified - previously the classes
were being defined globally rather than in the module.