### PR TITLE
Only require rspec/expectations when adding new matchers

### DIFF
--- a/lib/spec/matchers.rb
+++ b/lib/spec/matchers.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require 'rspec/expectations'
 require 'coach/middleware'
 
 # Middleware stubbing ######################################


### PR DESCRIPTION
For anyone using `rspec-rails`, the `require rspec` line here was a pain - it meant they needed to add `rspec` to their gemfile for no real benefit.