### PR TITLE
Upgrade Rubocop to 0.49.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,7 @@ Style/SignalException:
   EnforcedStyle: 'only_raise'
 
 # Use trailing rather than leading dots on multi-line call chains
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
 Lint/NestedMethodDefinition:
@@ -65,7 +65,7 @@ Style/AsciiComments:
   Enabled: false
 
 # Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle, SupportedLastArgumentHashStyles.
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
 # Configuration parameters: EnforcedStyle, SupportedStyles, ProceduralMethods, FunctionalMethods, IgnoredMethods.
@@ -76,7 +76,7 @@ Style/BlockDelimiters:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Style/ClosingParenthesisIndentation:
+Layout/ClosingParenthesisIndentation:
   Enabled: false
 
 # Configuration parameters: Keywords.
@@ -94,14 +94,14 @@ Style/GuardClause:
   Enabled: false
 
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/IndentHash:
+Layout/IndentHash:
   Enabled: false
 
 Style/Lambda:
   Enabled: false
 
 # Configuration parameters: EnforcedStyle, SupportedStyles.
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   Enabled: false
 
 # Configuration parameters: NamePrefix, NamePrefixBlacklist.
@@ -111,11 +111,11 @@ Style/PredicateName:
 Style/RedundantSelf:
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
 
 # Configuration parameters: MultiSpaceAllowedForOperators.
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Enabled: false
 
 # Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, Whitelist.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,26 +4,13 @@
 LineLength:
   Max: 90
 
-ClassLength:
-  Enabled: false
-
-ModuleLength:
-  Enabled: false
-
 # Avoid methods longer than 30 lines of code
 MethodLength:
   CountComments: false  # count full line comments?
-  Max: 87
-
-# Avoid single-line methods.
-SingleLineMethods:
-  AllowIfMethodIsEmpty: true
+  Max: 15
 
 StringLiterals:
   Enabled: false
-
-GlobalVars:
-  Enabled: false # We use them Redis + StatsD (though maybe we shouldn't?)
 
 # Wants underscores in all large numbers. Pain in the ass for things like
 # unix timestamps.
@@ -121,3 +108,6 @@ Layout/SpaceAroundOperators:
 # Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, Whitelist.
 Style/TrivialAccessors:
   Enabled: false
+
+Metrics/BlockLength:
+  Max: 110

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'rubocop', '~> 0.32.0'
+  spec.add_development_dependency 'rubocop', '~> 0.49.1'
 end

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'coach/version'
@@ -8,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.version       = Coach::VERSION
   spec.summary       = 'coach middleware'
   spec.description   = 'Controller framework'
-  spec.authors       = %w(GoCardless)
+  spec.authors       = %w[GoCardless]
   spec.homepage      = "https://github.com/gocardless/coach"
-  spec.email         = %w(developers@gocardless.com)
+  spec.email         = %w[developers@gocardless.com]
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -26,7 +26,7 @@ describe Coach::Handler do
       result = handler.call({})
       expect(a_spy).to have_received(:call)
       expect(b_spy).to have_received(:call)
-      expect(result).to eq(%w(A{} B{} Terminal{:handler=>true}))
+      expect(result).to eq(%w[A{} B{} Terminal{:handler=>true}])
     end
   end
 
@@ -94,7 +94,7 @@ describe Coach::Handler do
 
     it "sets up the chain correctly, calling each item in the correct order" do
       expect(handler.build_request_chain(sequence, {}).call).
-        to eq(%w(A{} B{:b=>true} Terminal{}))
+        to eq(%w[A{} B{:b=>true} Terminal{}])
     end
 
     context "with inheriting config" do
@@ -103,7 +103,7 @@ describe Coach::Handler do
 
       it "calls lambda with parent middlewares config" do
         expect(handler.build_request_chain(sequence, {}).call).
-          to eq(%w(A{} C{:b=>true} D{} B{:b=>true} Terminal{}))
+          to eq(%w[A{} C{:b=>true} D{} B{:b=>true} Terminal{}])
       end
     end
   end

--- a/spec/lib/coach/notifications_spec.rb
+++ b/spec/lib/coach/notifications_spec.rb
@@ -53,7 +53,7 @@ describe Coach::Notifications do
 
       it "contains all middleware that have been run" do
         middleware_names = middleware_event[:chain].map { |item| item[:name] }
-        expect(middleware_names).to include(*%w(Terminal A B))
+        expect(middleware_names).to include('Terminal', 'A', 'B')
       end
 
       it "includes all logged metadata" do

--- a/spec/lib/coach/request_benchmark_spec.rb
+++ b/spec/lib/coach/request_benchmark_spec.rb
@@ -36,7 +36,7 @@ describe Coach::RequestBenchmark do
 
     it "correctly orders chain" do
       chain_names = stats[:chain].map { |item| item[:name] }
-      expect(chain_names).to eq %w(A B)
+      expect(chain_names).to eq %w[A B]
     end
   end
 end

--- a/spec/lib/coach/router_spec.rb
+++ b/spec/lib/coach/router_spec.rb
@@ -13,7 +13,7 @@ describe Coach::Router do
 
   let(:resource_routes) do
     routes_module = Module.new
-    [:Index, :Show, :Create, :Update, :Destroy, :Refund].each do |class_name|
+    %i[Index Show Create Update Destroy Refund].each do |class_name|
       routes_module.const_set(class_name, Class.new)
     end
     routes_module


### PR DESCRIPTION
We were pointing to `0.32`, which is fairly old - this brings us up to speed.