### PR TITLE
Publish AS::Notifications even on errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ LineLength:
 # Avoid methods longer than 30 lines of code
 MethodLength:
   CountComments: false  # count full line comments?
-  Max: 15
+  Max: 16
 
 StringLiterals:
   Enabled: false
@@ -110,4 +110,5 @@ Style/TrivialAccessors:
   Enabled: false
 
 Metrics/BlockLength:
-  Max: 110
+  Exclude:
+    - "**/*_spec.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased changes
+
+# 0.4.6
+
+* [https://github.com/gocardless/coach/pull/22](#22) Publish ActiveSupport notifications
+  even on errors
+
 # 0.4.5 / 2017-04-26
 
 * [https://github.com/gocardless/coach/pull/17] Only require rspec/expectations

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -32,11 +32,11 @@ module Coach
         @benchmarks[event[:request].uuid] = RequestBenchmark.new(event[:middleware])
       end
 
-      @subscriptions << subscribe('middleware.finish') do |name, start, finish, _, event|
+      @subscriptions << subscribe('middleware.finish') do |_name, start, finish, _, event|
         log_middleware_finish(event, start, finish)
       end
 
-      @subscriptions << subscribe('handler.finish') do |name, start, finish, _, event|
+      @subscriptions << subscribe('handler.finish') do |_name, start, finish, _, event|
         log_handler_finish(event, start, finish)
       end
     end

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.4.5'.freeze
+  VERSION = '0.4.6'.freeze
 end


### PR DESCRIPTION
Currently, Coach is fairly agnostic about errors being raised within one of the middlewares. However, this leads to the unfortunate behaviour that error logging is abruptly terminated if the middleware raises an exception.

This means that any metadata from the request, that we had intentionally captured, is lost, and we only have request logs from the outer application to rely on.

This commit changes Coach::Handler to capture errors, report them on the new notification `coach.handler.error`, before re-raising the error to be handled downstream. This means that `coach.request` can also be emitted safely, allowing us to capture the request telemetry before the exception is passed on.