### PR TITLE
Add licence and contributing guidelines to Coach

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2017 GoCardless
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -292,3 +292,10 @@ solution to Rails `process_action.action_controller` event emitted on controller
 
 The benchmarking data includes information on how long each middleware took to process,
 along with the total duration of the chain.
+
+# License & Contributing
+
+* Coach is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+* Bug reports and pull requests are welcome on GitHub at https://github.com/gocardless/coach.
+
+GoCardless ♥ open source. If you do too, come [join us](https://gocardless.com/about/jobs).

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -7,8 +7,7 @@ require 'coach/version'
 Gem::Specification.new do |spec|
   spec.name          = 'coach'
   spec.version       = Coach::VERSION
-  spec.summary       = 'coach middleware'
-  spec.description   = 'Controller framework'
+  spec.summary       = 'Alternative controllers built with middleware'
   spec.authors       = %w[GoCardless]
   spec.homepage      = "https://github.com/gocardless/coach"
   spec.email         = %w[developers@gocardless.com]


### PR DESCRIPTION
This information is notably absent. We should probably drop something like this on the bottom of all our public repositories.