### PR TITLE
Use instrument for coach.handler.finish event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# Unreleased changes
+# CHANGELOG
+
+# 0.5.0 / 2017-08-07
+
+* [https://github.com/gocardless/coach/pull/24](#24) Use
+  ActiveSupport.instrument for coach.handler.finish event. Potentially breaking
+  change as the coach.handler.finish subscribers may trigger twice, depending on
+  how users have subscribed to them.
 
 # 0.4.6
 

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.4.6'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
This change uses ActiveSupport::Notifications.instrument to time and
publish the event for coach.handler.finish. This makes Coach consistent
with how it handles handler and middleware events. Such a change should
not break any integrations, but should probably be included in a minor bump.

The upshot of this is that integrating Coach with third-party
instrumentation tools then becomes a small bit easier. This is because
using #instrument over #publish will trigger start and end events under
the same key, if your subscriber is listening appropriately.