### PR TITLE
Capture the start time for the whole request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+# 0.5.1 / 2017-08-21
+
+* [https://github.com/gocardless/coach/pull/26](#26) Add `started_at` to the
+  request event metadata.
+
 # 0.5.0 / 2017-08-07
 
 * [https://github.com/gocardless/coach/pull/24](#24) Use

--- a/lib/coach/request_benchmark.rb
+++ b/lib/coach/request_benchmark.rb
@@ -22,6 +22,7 @@ module Coach
     end
 
     def complete(start, finish)
+      @start = start
       @duration = finish - start
     end
 
@@ -29,6 +30,7 @@ module Coach
     def stats
       {
         endpoint_name: @endpoint_name,
+        started_at: @start,
         duration: format_ms(@duration),
         chain: sorted_chain.map do |event|
           { name: event[:name], duration: format_ms(event[:duration]) }

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,3 @@
 module Coach
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end

--- a/spec/lib/coach/request_benchmark_spec.rb
+++ b/spec/lib/coach/request_benchmark_spec.rb
@@ -26,6 +26,14 @@ describe Coach::RequestBenchmark do
       expect(stats[:duration]).to eq(5000)
     end
 
+    it "captures the endpoint_name" do
+      expect(stats[:endpoint_name]).to eq("ENDPOINT")
+    end
+
+    it "captures the started_at time" do
+      expect(stats[:started_at]).to eq(base_time)
+    end
+
     it "computes duration of middleware with no children" do
       expect(stats[:chain]).to include(name: 'B', duration: 1000)
     end


### PR DESCRIPTION
Coach is very useful for capturing the duration of the middlewares within the request, but does not yield any information about the start of the first request (even though this is captured by RequestBenchmark).

This commit stores, and exposes, the initial start time of the request, which can be used by downstream subscribers for more complex calculations.