### PR TITLE
Deprecate support for Ruby 2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_gem:
   gc_ruboconfig: rubocop.yml
 
+AllCops:
+  TargetRubyVersion: 2.2
+
 Style/RescueStandardError:
   Exclude:
     - "*/**/*_spec.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,10 @@ rvm:
   - 2.4.1
   - 2.3.4
   - 2.2.4
-  - 2.1
 
 env:
   - "RAILS_VERSION=4.2.6"
   - "RAILS_VERSION=5.0.2"
-
-matrix:
-  exclude:
-    - rvm: 2.1
-      env: "RAILS_VERSION=5.0.2"
 
 script:
   - bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Coach improves your controller code by encouraging:
 - **Testability** - Test each middleware in isolation, with effortless mocking of test
   data and natural RSpec matchers.
 
+# Installation
+
+To get started, just add Coach to your `Gemfile`, and then run `bundle`:
+
+```ruby
+gem 'coach', '~> 0.5.2'
+```
+
 ## Coach by example
 
 The best way to see the benefits of Coach is with a demonstration.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To get started, just add Coach to your `Gemfile`, and then run `bundle`:
 gem 'coach', '~> 0.5.2'
 ```
 
+Coach works with Ruby versions 2.2 and onwards.
+
 ## Coach by example
 
 The best way to see the benefits of Coach is with a demonstration.

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/gocardless/coach"
   spec.email         = %w[developers@gocardless.com]
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 2.2"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^spec/})


### PR DESCRIPTION
Support for Ruby 2.1 [ended][1] on 1st April 2017. This drops support for it in the gem, so we now support Ruby 2.2, Ruby 2.3, Ruby 2.4 and Ruby 2.5.

We do that by:

* Setting the `required_ruby_version` in the gemspec
* Stopping running tests in Travis CI on Ruby 2.1
* Reconfiguring Rubocop to use target Ruby 2.2 onwards

This PR will be followed by one which will move our CI pipeline to CircleCI, for consistency with other GoCardless projects.

[1]: https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/