### PR TITLE
Switch to reverse domain named keys for instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,13 +294,13 @@ Information for how to use `ActiveSupport`s notifications can be found
 
 | Event                         | Arguments                                              |
 |-------------------------------|------------------------------------------------------- |
-| `coach.handler.start`     | `event(:middleware, :request)`                         |
-| `coach.middleware.start`  | `event(:middleware, :request)`                         |
-| `coach.middleware.finish` | `start`, `finish`, `id`, `event(:middleware, :request)`|
-| `coach.handler.finish`    | `start`, `finish`, `id`, `event(:middleware, :request)`|
-| `coach.request`           | `event` containing request data and benchmarking       |
+| `start_handler.coach`     | `event(:middleware, :request)`                         |
+| `start_middleware.coach`  | `event(:middleware, :request)`                         |
+| `finish_middleware.coach` | `start`, `finish`, `id`, `event(:middleware, :request)`|
+| `finish_handler.coach`    | `start`, `finish`, `id`, `event(:middleware, :request)`|
+| `request.coach`           | `event` containing request data and benchmarking       |
 
-Of special interest is `coach.request`, which publishes statistics on an entire
+Of special interest is `request.coach`, which publishes statistics on an entire
 middleware chain and request. This data is particularly useful for logging, and is our
 solution to Rails `process_action.action_controller` event emitted on controller requests.
 

--- a/lib/coach/request_benchmark.rb
+++ b/lib/coach/request_benchmark.rb
@@ -1,6 +1,6 @@
 module Coach
   # This class is built to aggregate data during the course of the request. It relies on
-  # 'coach.middleware.start' and 'coach.middleware.end' events to register the
+  # 'start_middleware.coach' and 'finish_middleware.coach' events to register the
   # start/end of each middleware element, and thereby calculate running times for each.
   #
   # Coach::Notifications makes use of this class to produce benchmark data for

--- a/spec/lib/coach/notifications_spec.rb
+++ b/spec/lib/coach/notifications_spec.rb
@@ -12,7 +12,7 @@ describe Coach::Notifications do
       to receive(:new).
       and_return(instance_double("Coach::RequestSerializer", serialize: {}))
 
-    ActiveSupport::Notifications.subscribe(/coach/) do |name, *_, event|
+    ActiveSupport::Notifications.subscribe(/\.coach$/) do |name, *_, event|
       events << [name, event]
     end
   end
@@ -20,7 +20,7 @@ describe Coach::Notifications do
   # Capture all Coach events
   let(:events) { [] }
   let(:middleware_event) do
-    event = events.find { |(name, _)| name == "coach.request" }
+    event = events.find { |(name, _)| name == "request.coach" }
     event && event[1]
   end
 
@@ -44,12 +44,12 @@ describe Coach::Notifications do
       expect(notifications.active?).to be(true)
     end
 
-    it "will now send coach.request" do
+    it "will now send request.coach" do
       handler.call({})
       expect(middleware_event).to_not be_nil
     end
 
-    describe "coach.request event" do
+    describe "request.coach event" do
       before { handler.call({}) }
 
       it "contains all middleware that have been run" do
@@ -69,13 +69,13 @@ describe Coach::Notifications do
       notifications.subscribe!
 
       handler.call({})
-      expect(events.count { |(name, _)| name == "coach.request" }).
+      expect(events.count { |(name, _)| name == "request.coach" }).
         to eq(1)
 
       notifications.unsubscribe!
 
       handler.call({})
-      expect(events.count { |(name, _)| name == "coach.request" }).
+      expect(events.count { |(name, _)| name == "request.coach" }).
         to eq(1)
     end
   end


### PR DESCRIPTION
The conventional structure of ActiveSupport::Notification keys is
"event.library". However, coach used "library.event". This commit
adds support for the preferred style and deprecates the old one
for removal in a future version.