### PR TITLE
DET-69 Report `duration` in seconds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.2
 
+Metrics/MethodLength:
+  Max: 15
+
 Style/RescueStandardError:
   Exclude:
     - "*/**/*_spec.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * [#60](https://github.com/gocardless/coach/pull/60) Add `Middleware.requires?`, which
   behaves like `Middleware.provides?` but for requirements.
 
+* [#52](https://github.com/gocardless/coach/pull/52) Add `duration_seconds` to statistic
+  logging. The `duration` field is now deprecated and will be removed in a future release.
+
 ## Breaking changes
 
 * [#70](https://github.com/gocardless/coach/pull/70) The following deprecated event names have been removed:

--- a/lib/coach/request_benchmark.rb
+++ b/lib/coach/request_benchmark.rb
@@ -32,8 +32,13 @@ module Coach
         endpoint_name: @endpoint_name,
         started_at: @start,
         duration: format_ms(@duration),
+        duration_seconds: @duration,
         chain: sorted_chain.map do |event|
-          { name: event[:name], duration: format_ms(event[:duration]) }
+          {
+            name: event[:name],
+            duration: format_ms(event[:duration]),
+            duration_seconds: event[:duration],
+          }
         end,
       }
     end

--- a/lib/coach/rspec.rb
+++ b/lib/coach/rspec.rb
@@ -3,7 +3,6 @@ require "coach/middleware"
 
 # Middleware stubbing ######################################
 
-# rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/AbcSize
 def build_middleware(name)
   Class.new(Coach::Middleware) do
@@ -28,7 +27,6 @@ def build_middleware(name)
   end
 end
 # rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/MethodLength
 
 def null_middleware
   double(call: nil)

--- a/spec/lib/coach/request_benchmark_spec.rb
+++ b/spec/lib/coach/request_benchmark_spec.rb
@@ -24,6 +24,7 @@ describe Coach::RequestBenchmark do
 
     it "computes overall duration" do
       expect(stats[:duration]).to eq(5000)
+      expect(stats[:duration_seconds]).to eq(5.0)
     end
 
     it "captures the endpoint_name" do
@@ -35,11 +36,11 @@ describe Coach::RequestBenchmark do
     end
 
     it "computes duration of middleware with no children" do
-      expect(stats[:chain]).to include(name: "B", duration: 1000)
+      expect(stats[:chain]).to include(name: "B", duration: 1000, duration_seconds: 1.0)
     end
 
     it "adjusts duration of middleware for their children" do
-      expect(stats[:chain]).to include(name: "A", duration: 2000)
+      expect(stats[:chain]).to include(name: "A", duration: 2000, duration_seconds: 2.0)
     end
 
     it "correctly orders chain" do


### PR DESCRIPTION
As per our logging guidelines, `duration` should be in seconds everywhere possible, not `ms`