### PR TITLE
Rename field `session_id` to `session_ip`

### DIFF
--- a/lib/coach/request_serializer.rb
+++ b/lib/coach/request_serializer.rb
@@ -39,7 +39,7 @@ module Coach
 
         # Extra request info
         headers: filtered_headers,
-        session_id: @request.remote_ip,
+        session_ip: @request.remote_ip,
       }
     end
 


### PR DESCRIPTION
 This field name was a typo. It contains an IP, and it was always meant to be called `session_ip`