### PR TITLE
Rename `response.status` field to just `status`

### DIFF
--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -41,7 +41,7 @@ module Coach
           # This way, the last finish_handler.coach event will have all the details.
           status = response.try(:first) || STATUS_CODE_FOR_EXCEPTIONS
           event.merge!(
-            response: { status: status },
+            status: status,
             metadata: context.fetch(:_metadata, {}),
           )
         end

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -174,7 +174,7 @@ describe Coach::Handler do
         it "captures the error event with the metadata" do
           is_expected.
             to include(["finish_handler.coach", hash_including(
-              response: { status: 500 },
+              status: 500,
               metadata: { A: true },
             )])
         end
@@ -239,7 +239,7 @@ describe Coach::Handler do
           it "captures the error event with the metadata" do
             is_expected.
               to include(["coach.handler.finish", hash_including(
-                response: { status: 500 },
+                status: 500,
                 metadata: { A: true },
               )])
           end


### PR DESCRIPTION
This is more closely aligned with our logging guidelines.