### PR TITLE
Deprecate support for Ruby 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,18 +33,6 @@ references:
 
     - run: bundle exec rubocop
 jobs:
-  build-ruby23-rails515:
-    docker:
-      - image: ruby:2.3
-        environment:
-          - RAILS_VERSION=5.1.5
-    steps: *steps
-  build-ruby23-rails4210:
-    docker:
-      - image: ruby:2.3
-        environment:
-          - RAILS_VERSION=4.2.10
-    steps: *steps
   build-ruby24-rails515:
     docker:
       - image: ruby:2.4
@@ -74,8 +62,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby23-rails515
-      - build-ruby23-rails4210
       - build-ruby24-rails515
       - build-ruby24-rails4210
       - build-ruby25-rails515

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,18 +33,6 @@ references:
 
     - run: bundle exec rubocop
 jobs:
-  build-ruby22-rails515:
-    docker:
-      - image: ruby:2.2
-        environment:
-          - RAILS_VERSION=5.1.5
-    steps: *steps
-  build-ruby22-rails4210:
-    docker:
-      - image: ruby:2.2
-        environment:
-          - RAILS_VERSION=4.2.10
-    steps: *steps
   build-ruby23-rails515:
     docker:
       - image: ruby:2.3
@@ -86,8 +74,6 @@ workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby22-rails515
-      - build-ruby22-rails4210
       - build-ruby23-rails515
       - build-ruby23-rails4210
       - build-ruby24-rails515

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
   gc_ruboconfig: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Metrics/MethodLength:
   Max: 15

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
   gc_ruboconfig: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/MethodLength:
   Max: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   * `coach.handler.finish`
   * `coach.request`
 
+* [#56](https://github.com/gocardless/coach/pull/56) Support for Ruby 2.2 and 2.3 has been
+  dropped. See our [compatibility policy](https://github.com/gocardless/coach/blob/master/docs/COMPATIBILITY.md) for more information.
+
 # 1.0.0 / 2018-04-19
 
 ## Breaking changes

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To get started, just add Coach to your `Gemfile`, and then run `bundle`:
 gem 'coach'
 ```
 
-Coach works with Ruby versions 2.2 and onwards.
+Coach works with Ruby versions 2.3 and onwards.
 
 ## Coach by example
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To get started, just add Coach to your `Gemfile`, and then run `bundle`:
 gem 'coach'
 ```
 
-Coach works with Ruby versions 2.3 and onwards.
+Coach works with Ruby versions 2.4 and onwards.
 
 ## Coach by example
 

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/gocardless/coach"
   spec.email         = %w[developers@gocardless.com]
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.4"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^spec/})

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/gocardless/coach"
   spec.email         = %w[developers@gocardless.com]
   spec.license       = "MIT"
-  spec.required_ruby_version = ">= 2.2"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^spec/})

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "coach/version"

--- a/lib/coach.rb
+++ b/lib/coach.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support"
 require "action_dispatch"
 

--- a/lib/coach/errors.rb
+++ b/lib/coach/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Coach
   module Errors
     class MiddlewareDependencyNotMet < StandardError

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coach/errors"
 require "active_support/core_ext/object/try"
 

--- a/lib/coach/middleware.rb
+++ b/lib/coach/middleware.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coach/middleware_item"
 
 module Coach

--- a/lib/coach/middleware_item.rb
+++ b/lib/coach/middleware_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coach/errors"
 require "coach/middleware_validator"
 
@@ -13,7 +15,7 @@ module Coach
     def build_middleware(context, successor)
       @middleware.
         new(context,
-            successor && successor.instrument,
+            successor&.instrument,
             config)
     end
 

--- a/lib/coach/middleware_validator.rb
+++ b/lib/coach/middleware_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coach/errors"
 
 module Coach

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "request_benchmark"
 require_relative "request_serializer"
 

--- a/lib/coach/request_benchmark.rb
+++ b/lib/coach/request_benchmark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Coach
   # This class is built to aggregate data during the course of the request. It relies on
   # 'start_middleware.coach' and 'finish_middleware.coach' events to register the

--- a/lib/coach/request_serializer.rb
+++ b/lib/coach/request_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Coach
   class RequestSerializer
     def self.header_rules

--- a/lib/coach/router.rb
+++ b/lib/coach/router.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "handler"
 require_relative "errors"
 

--- a/lib/coach/rspec.rb
+++ b/lib/coach/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/expectations"
 require "coach/middleware"
 

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Coach
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.0"
 end

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "coach/handler"

--- a/spec/lib/coach/middleware_spec.rb
+++ b/spec/lib/coach/middleware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "coach/middleware"
 
 describe Coach::Middleware do

--- a/spec/lib/coach/middleware_validator_spec.rb
+++ b/spec/lib/coach/middleware_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "coach/middleware_validator"
 

--- a/spec/lib/coach/notifications_spec.rb
+++ b/spec/lib/coach/notifications_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "coach/notifications"
 

--- a/spec/lib/coach/request_benchmark_spec.rb
+++ b/spec/lib/coach/request_benchmark_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "coach/request_benchmark"
 

--- a/spec/lib/coach/request_serializer_spec.rb
+++ b/spec/lib/coach/request_serializer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "active_support/core_ext/object/try"
 require "coach/request_serializer"

--- a/spec/lib/coach/router_spec.rb
+++ b/spec/lib/coach/router_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "coach/router"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/its"
 require "pry"
 require "coach"


### PR DESCRIPTION
Ruby 2.2 was end-of-lifed on 2018-03-31

https://www.ruby-lang.org/en/downloads/branches/