### PR TITLE
Revert "Rename field `session_id` to `session_ip`"

### DIFF
--- a/lib/coach/request_serializer.rb
+++ b/lib/coach/request_serializer.rb
@@ -39,7 +39,7 @@ module Coach
 
         # Extra request info
         headers: filtered_headers,
-        session_ip: @request.remote_ip,
+        session_id: @request.remote_ip,
       }
     end
 


### PR DESCRIPTION
Reverts gocardless/coach#54

Since we're not doing the upgrade to `v2.0` yet, and this is a breaking change, it has to be reversed