### PR TITLE
Rename field `session_id` to `session_ip`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+# Unreleased
+
+* [#59](https://github.com/gocardless/coach/pull/59) Request data included in the
+  `request.coach` event includes a `session_ip` field which replaces the erroneously named
+  `session_id`. The latter is deprecated and will be removed in a future release.
+
 # 1.0.0 / 2018-04-19
 
 ## Breaking changes

--- a/lib/coach/request_serializer.rb
+++ b/lib/coach/request_serializer.rb
@@ -40,7 +40,7 @@ module Coach
 
         # Extra request info
         headers: filtered_headers,
-        session_id: @request.remote_ip,
+        session_ip: @request.remote_ip,
       }
     end
 

--- a/lib/coach/request_serializer.rb
+++ b/lib/coach/request_serializer.rb
@@ -40,6 +40,7 @@ module Coach
 
         # Extra request info
         headers: filtered_headers,
+        session_id: @request.remote_ip, # TODO: remove in a future release
         session_ip: @request.remote_ip,
       }
     end


### PR DESCRIPTION
This field name was a typo. It contains an IP, and it was always meant to be called session_ip

Will be done when we create version `v2.0` with all the other breaking changes