### PR TITLE
Add CLI, implement find-provider and find-chain commands

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,11 @@ AllCops:
 Metrics/MethodLength:
   Max: 15
 
+# Even after some serious refactoring, the default of 15 can be hard to meet
+# if you favour saving intermediate state into well-named variables
+Metrics/AbcSize:
+  Max: 20
+
 Style/RescueStandardError:
   Exclude:
     - "*/**/*_spec.rb"

--- a/README.md
+++ b/README.md
@@ -334,6 +334,77 @@ class Tracking < Coach::Middleware
 end
 ```
 
+# Coach CLI
+
+As well as the library, the Coach gem comes with a command line tool - `coach`.
+
+When working in a large codebase that uses Coach, one of the challenges you may run into
+is understanding the `provide`/`require` graph made up of all the middleware chains you've
+built. While the library enforces the correctness of those chains at boot time, it doesn't
+help you understand those dependencies. That's where the `coach` CLI comes in!
+
+Currently, the `coach` CLI supports two commands.
+
+## `find-provider`
+
+`find-provider` is the simpler of the two commands. Given the name of a Coach middleware
+and a value that it requires, it outputs the name of the middleware that provides it.
+
+```bash
+$ bundle exec coach find-provider HelloUser user
+Value `user` is provided to `HelloUser` by:
+
+Authentication
+```
+
+If there are multiple middlewares in the chain that provide the same value, all of them
+will be listed.
+
+## `find-chain`
+
+`find-chain` is the more advanced of the two commands, and is most useful in larger
+codebases. Given the name of a Coach middleware and a value it requires, it outputs the
+chains of middleware between the specified middleware and the one that provides the
+required value.
+
+```bash
+# Note that we've assumed an intermediate middleware - `UserDecorator` exists in this
+# example to make the functionality of the command clearer.
+$ bundle exec coach find-chain HelloUser user
+Value `user` is provided to `HelloUser` by:
+
+HelloUser -> UserDecorator -> Authentication
+```
+
+If there are multiple paths to a middleware that provides that value, all of them will be
+listed. Similarly, if multiple middlewares provide the same value, all of them will be
+listed.
+
+## Spring integration
+
+Given that the Coach CLI is mostly aimed at large Rails apps using Coach, it would be an
+oversight for us not to integrate it with [Spring](https://github.com/rails/spring/).
+
+To enable the use of Spring with the Coach CLI, add the following to `config/spring.rb` or
+an equivalent Rails config file.
+
+```ruby
+require "spring/commands/coach"
+```
+
+On GoCardless' main Rails app, using Spring reduces the time to run `coach` commands from
+around 15s to 1s.
+
+## Future work
+
+While we think the commands we've already built are useful, we do have some ideas to go
+further, including:
+
+  - Better formatting of provider chains
+  - Outputting DOT format files to visualise with Graphviz
+  - Editor integrations (e.g. showing the provider chains when hovering a `requires`
+    statement)
+
 # License & Contributing
 
 * Coach is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/bin/coach
+++ b/bin/coach
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require "slop"
+require "coach/cli/provider_finder"
+
+begin
+  require File.join(Dir.pwd, "config/environment")
+rescue LoadError
+  puts <<~EOS
+    Could not load your Rails app
+    =============================
+
+    Currently the coach CLI assumes you have a config/environment.rb file that
+    we can load. We believe this is true of Rails apps in general.
+
+    Please raise an issue if that's not the case!
+
+    https://github.com/gocardless/coach/issues
+  EOS
+  exit 1
+end
+
+Slop.parse do
+  command "find-provider" do
+    run do |_, args|
+      unless args.length == 2
+        raise "Two args please!"
+      end
+      Coach::Cli::ProviderFinder.new(args[0], args[1]).run
+    end
+  end
+end

--- a/bin/coach
+++ b/bin/coach
@@ -26,7 +26,13 @@ Slop.parse do
       unless args.length == 2
         raise "Two args please!"
       end
-      Coach::Cli::ProviderFinder.new(args[0], args[1]).find_provider
+      middleware_name = args[0]
+      value_name = args[1]
+
+      result = Coach::Cli::ProviderFinder.new(args[0], args[1]).find_provider
+
+      puts "Value `#{value_name}` is provided to `#{middleware_name}` by:\n\n"
+      puts result.to_a.join("\n")
     end
   end
 

--- a/bin/coach
+++ b/bin/coach
@@ -41,7 +41,23 @@ Slop.parse do
       unless args.length == 2
         raise "Two args please!"
       end
-      Coach::Cli::ProviderFinder.new(args[0], args[1]).find_chain
+      middleware_name = args[0]
+      value_name = args[1]
+
+      chains = Coach::Cli::ProviderFinder.new(middleware_name, value_name).find_chain
+
+      if chains.size > 1
+        puts "Value `#{value_name}` is provided to `#{middleware_name}` " \
+          "by multiple middleware chains:\n\n"
+      else
+        puts "Value `#{value_name}` is provided to `#{middleware_name}` by:\n\n"
+      end
+
+      formatted_chains = chains.map do |chain|
+        chain.join(" -> ")
+      end.join("\n---\n")
+
+      puts formatted_chains
     end
   end
 end

--- a/bin/coach
+++ b/bin/coach
@@ -26,7 +26,16 @@ Slop.parse do
       unless args.length == 2
         raise "Two args please!"
       end
-      Coach::Cli::ProviderFinder.new(args[0], args[1]).run
+      Coach::Cli::ProviderFinder.new(args[0], args[1]).find_provider
+    end
+  end
+
+  command "find-chain" do
+    run do |_, args|
+      unless args.length == 2
+        raise "Two args please!"
+      end
+      Coach::Cli::ProviderFinder.new(args[0], args[1]).find_chain
     end
   end
 end

--- a/bin/coach
+++ b/bin/coach
@@ -23,11 +23,8 @@ end
 Slop.parse do
   command "find-provider" do
     run do |_, args|
-      unless args.length == 2
-        raise "Two args please!"
-      end
-      middleware_name = args[0]
-      value_name = args[1]
+      middleware_name, value_name = *args
+      raise ArgumentError, "middleware_name and value_name required" unless middleware_name && value_name
 
       result = Coach::Cli::ProviderFinder.new(args[0], args[1]).find_provider
 
@@ -38,11 +35,8 @@ Slop.parse do
 
   command "find-chain" do
     run do |_, args|
-      unless args.length == 2
-        raise "Two args please!"
-      end
-      middleware_name = args[0]
-      value_name = args[1]
+      middleware_name, value_name = *args
+      raise ArgumentError, "middleware_name and value_name required" unless middleware_name && value_name
 
       chains = Coach::Cli::ProviderFinder.new(middleware_name, value_name).find_chain
 

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -17,9 +17,13 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
+  spec.executables   = ["coach"]
 
   spec.add_dependency "actionpack", ">= 4.2"
   spec.add_dependency "activesupport", ">= 4.2"
+  # TODO: Find another CLI parser that supports subcommands
+  # Slop v4 got rid of them :(
+  spec.add_dependency "slop", "~> 3.6"
 
   spec.add_development_dependency "gc_ruboconfig", "= 2.8.0"
   spec.add_development_dependency "pry", "~> 0.10"

--- a/lib/coach/cli/errors.rb
+++ b/lib/coach/cli/errors.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Coach
+  module Cli
+    class Error < StandardError; end
+
+    module Errors
+      class MiddlewareNotFoundError < Error
+        attr_reader :middleware_name
+
+        def initialize(middleware_name)
+          @middleware_name = middleware_name
+
+          super("Middleware #{@middleware_name} not found")
+        end
+      end
+
+      class ValueNotRequiredError < Error
+        attr_reader :value_name
+
+        def initialize(middleware_name, value_name)
+          @middleware_name = middleware_name
+          @value_name = value_name
+
+          super("Middleware #{@middleware_name} doesn't require value #{value_name}")
+        end
+      end
+
+      class ValueNotProvidedError < Error
+        attr_reader :value_name
+
+        def initialize(middleware_name, value_name)
+          @middleware_name = middleware_name
+          @value_name = value_name
+
+          super("Middleware #{@middleware_name} isn't provided with value #{value_name}")
+        end
+      end
+    end
+  end
+end

--- a/lib/coach/cli/provider_finder.rb
+++ b/lib/coach/cli/provider_finder.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Coach
+  module Cli
+    class ProviderFinder
+      def initialize(middleware_name, value_name)
+        @middleware_name = middleware_name
+        @value_name = value_name
+      end
+
+      def run
+        if Module.const_defined?(@middleware_name)
+          middleware = Module.const_get(@middleware_name)
+        else
+          raise "That middleware doesn't exist!"
+        end
+
+        provider_mapping = build_provider_mapping(middleware, Hash.new { Set.new })
+
+        if provider_mapping.key?(@value_name.to_sym)
+          providers = provider_mapping[@value_name.to_sym]
+        else
+          raise "That value isn't provided!"
+        end
+
+        puts "Value `#{@value_name}` is provided by:\n\n"
+        puts providers.to_a.join("\n")
+      end
+
+      def build_provider_mapping(middleware, mapping)
+        middleware.provided.each do |p|
+          mapping[p] = mapping[p].add(middleware)
+        end
+
+        middleware.middleware_dependencies.each do |dep|
+          build_provider_mapping(dep.middleware, mapping)
+        end
+
+        mapping
+      end
+    end
+  end
+end

--- a/lib/coach/cli/provider_finder.rb
+++ b/lib/coach/cli/provider_finder.rb
@@ -10,7 +10,7 @@ module Coach
         @value_name = value_name
       end
 
-      def run
+      def find_provider
         if Module.const_defined?(@middleware_name)
           middleware = Module.const_get(@middleware_name)
         else
@@ -25,9 +25,40 @@ module Coach
           raise "That value isn't provided!"
         end
 
-        puts "Value `#{@value_name}` is provided by:\n\n"
+        puts "Value `#{@value_name}` is provided to `#{@middleware_name}` by:\n\n"
         puts providers.to_a.join("\n")
       end
+
+      def find_chain
+        if Module.const_defined?(@middleware_name)
+          middleware = Module.const_get(@middleware_name)
+        else
+          raise "That middleware doesn't exist!"
+        end
+
+        provider_chain = build_provider_chain(middleware, Hash.new { Set.new }, [])
+
+        if provider_chain.key?(@value_name.to_sym)
+          chains = provider_chain[@value_name.to_sym]
+        else
+          raise "That value isn't provided!"
+        end
+
+        if chains.size > 1
+          puts "Value `#{@value_name}` is provided to `#{@middleware_name}` " \
+            "by multiple middleware chains:\n\n"
+        else
+          puts "Value `#{@value_name}` is provided to `#{@middleware_name}` by:\n\n"
+        end
+
+        formatted_chains = chains.map do |chain|
+          chain.join(" -> ")
+        end.join("\n---\n")
+
+        puts formatted_chains
+      end
+
+      private
 
       def build_provider_mapping(middleware, mapping)
         middleware.provided.each do |p|
@@ -36,6 +67,20 @@ module Coach
 
         middleware.middleware_dependencies.each do |dep|
           build_provider_mapping(dep.middleware, mapping)
+        end
+
+        mapping
+      end
+
+      def build_provider_chain(middleware, mapping, chain)
+        new_chain = chain + [middleware]
+
+        middleware.provided.each do |p|
+          mapping[p] = mapping[p].add(new_chain)
+        end
+
+        middleware.middleware_dependencies.each do |dep|
+          build_provider_chain(dep.middleware, mapping, new_chain)
         end
 
         mapping

--- a/lib/spring/commands/coach.rb
+++ b/lib/spring/commands/coach.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spring
+  module Commands
+    class Coach
+      def env(*)
+        "development"
+      end
+
+      def exec_name
+        "coach"
+      end
+
+      Spring.register_command "coach", Coach.new
+    end
+  end
+end

--- a/spec/lib/coach/cli/provider_finder_spec.rb
+++ b/spec/lib/coach/cli/provider_finder_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "coach/cli/provider_finder"
+
+describe Coach::Cli::ProviderFinder do
+  subject(:provider_finder) { described_class.new(middleware_name, value_name) }
+
+  let(:middleware_name) { "" }
+  let(:value_name) { "" }
+
+  describe "#find_provider" do
+    context "when there is a single provider" do
+      let(:middleware_name) { "RequiringMiddleware" }
+      let(:value_name) { "provided_value" }
+
+      before do
+        stub_const("ProvidingMiddleware", Class.new(Coach::Middleware) do
+          provides :provided_value
+        end)
+        stub_const(middleware_name, Class.new(Coach::Middleware) do
+          uses ProvidingMiddleware
+
+          requires :provided_value
+        end)
+      end
+
+      it "returns the providing middleware" do
+        expect(provider_finder.find_provider).to eq %w[ProvidingMiddleware]
+      end
+    end
+
+    context "when there are multiple providers" do
+      let(:middleware_name) { "RequiringMiddleware" }
+      let(:value_name) { "provided_value" }
+
+      before do
+        stub_const("FirstProvidingMiddleware", Class.new(Coach::Middleware) do
+          provides :provided_value
+        end)
+        stub_const("SecondProvidingMiddleware", Class.new(Coach::Middleware) do
+          provides :provided_value
+        end)
+        stub_const(middleware_name, Class.new(Coach::Middleware) do
+          uses FirstProvidingMiddleware
+          uses SecondProvidingMiddleware
+
+          requires :provided_value
+        end)
+      end
+
+      it "returns the providing middleware" do
+        expect(provider_finder.find_provider).
+          to eq %w[FirstProvidingMiddleware SecondProvidingMiddleware]
+      end
+    end
+
+    context "when there's an intermediate middleware after the provider" do
+      let(:middleware_name) { "RequiringMiddleware" }
+      let(:value_name) { "provided_value" }
+
+      before do
+        stub_const("ProvidingMiddleware", Class.new(Coach::Middleware) do
+          provides :provided_value
+        end)
+        stub_const("IntermediateMiddleware", Class.new(Coach::Middleware) do
+          uses ProvidingMiddleware
+        end)
+        stub_const(middleware_name, Class.new(Coach::Middleware) do
+          uses IntermediateMiddleware
+
+          requires :provided_value
+        end)
+      end
+
+      it "returns the providing middleware" do
+        expect(provider_finder.find_provider).to eq %w[ProvidingMiddleware]
+      end
+    end
+
+    context "when the middleware can't be found" do
+      let(:middleware_name) { "MiddlewareThatDoesntExist" }
+
+      it "raises a MiddlewareNotFoundError" do
+        expect { provider_finder.find_provider }.
+          to raise_error(Coach::Cli::Errors::MiddlewareNotFoundError)
+      end
+    end
+
+    context "when the middleware doesn't require the specified value" do
+      let(:middleware_name) { "MiddlewareWithoutRequires" }
+      let(:value_name) { "value_that_doesnt_exist" }
+
+      before do
+        stub_const(middleware_name, Class.new(Coach::Middleware))
+      end
+
+      it "raises a ValueNotRequiredError" do
+        expect { provider_finder.find_provider }.
+          to raise_error(Coach::Cli::Errors::ValueNotRequiredError)
+      end
+    end
+
+    context "when the middleware isn't provided with a value it requires" do
+      let(:middleware_name) { "MiddlewareWithMissingProvide" }
+      let(:value_name) { "value_that_isnt_provided" }
+
+      before do
+        stub_const(middleware_name, Class.new(Coach::Middleware) do
+          requires :value_that_isnt_provided
+        end)
+      end
+
+      it "raises a ValueNotProvidedError" do
+        expect { provider_finder.find_provider }.
+          to raise_error(Coach::Cli::Errors::ValueNotProvidedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new `coach` CLI that's bundled with the gem.

There's tonnes more that we could do with this, but it feels shippable now that it's been refactored pretty extensively from its original hackday form through tests.

Hopefully this is the start of us making Coach easier to use on really large codebases.

I've updated `README.md` with details on what it is and how to use it.