### PR TITLE
Drop deprecated notification format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
     - type: cache-restore
       key: coach-bundler-{{ checksum "coach.gemspec" }}-{{ checksum "~/RAILS_VERSION.txt" }}
 
-    - run: gem install bundler
+    - run: gem install bundler -v 1.11.2
 
     - run: bundle install --path vendor/bundle
 

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -28,8 +28,8 @@ module Coach
 
       event = build_event(context)
 
-      publish_start(event.dup)
-      instrumented_call(event) do
+      publish("start_handler.coach", event.dup)
+      instrument("finish_handler.coach", event) do
         begin
           response = chain.instrument.call
         ensure
@@ -86,29 +86,6 @@ module Coach
         middleware: @root_item.middleware.name,
         request: context[:request],
       }
-    end
-
-    def publish_start(event)
-      if notifier.listening?("coach.handler.start")
-        ActiveSupport::Deprecation.warn("The 'coach.handler.start' event has been " \
-          "renamed to 'start_handler.coach' and the old name will be removed in a " \
-          "future version.")
-        publish("coach.handler.start", event)
-      end
-      publish("start_handler.coach", event)
-    end
-
-    def instrumented_call(event, &block)
-      if notifier.listening?("coach.handler.finish")
-        ActiveSupport::Deprecation.warn("The 'coach.handler.find' event has been " \
-          "renamed to 'finish_handler.coach' and the old name will be removed in a " \
-          "future version.")
-        instrument("coach.handler.finish", event) do
-          instrument("finish_handler.coach", event, &block)
-        end
-      else
-        instrument("finish_handler.coach", event, &block)
-      end
     end
   end
 end

--- a/lib/coach/middleware.rb
+++ b/lib/coach/middleware.rb
@@ -77,14 +77,10 @@ module Coach
     # Use ActiveSupport to instrument the execution of the subsequent chain.
     def instrument
       proc do
-        publish_start
+        ActiveSupport::Notifications.publish("start_middleware.coach", middleware_event)
 
-        if ActiveSupport::Notifications.notifier.listening?("coach.middleware.finish")
-          instrument_deprecated { call }
-        else
-          ActiveSupport::Notifications.
-            instrument("finish_middleware.coach", middleware_event) { call }
-        end
+        ActiveSupport::Notifications.
+          instrument("finish_middleware.coach", middleware_event) { call }
       end
     end
 
@@ -109,29 +105,6 @@ module Coach
         middleware: self.class.name,
         request: request,
       }
-    end
-
-    def publish_start
-      if ActiveSupport::Notifications.notifier.listening?("coach.middleware.start")
-        ActiveSupport::Deprecation.warn("The 'coach.middleware.start' event has " \
-          "been renamed to 'start_middleware.coach' and the old name will be " \
-          "removed in a future version.")
-        ActiveSupport::Notifications.
-          publish("coach.middleware.start", middleware_event)
-      end
-      ActiveSupport::Notifications.
-        publish("start_middleware.coach", middleware_event)
-    end
-
-    def instrument_deprecated(&block)
-      ActiveSupport::Deprecation.warn("The 'coach.middleware.finish' event has " \
-        "been renamed to 'finish_middleware.coach' and the old name will be " \
-        "removed in a future version.")
-      ActiveSupport::Notifications.
-        instrument("coach.middleware.finish", middleware_event) do
-        ActiveSupport::Notifications.
-          instrument("finish_middleware.coach", middleware_event, &block)
-      end
     end
   end
 end

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -64,10 +64,7 @@ module Coach
     end
 
     def subscribe(event, &block)
-      # New key formats don't include a period. If they do, they're the old deprecated
-      # format. No need to warn here since the warnings will show up from elsewhere.
-      key = event.include?(".") ? "coach.#{event}" : "#{event}.coach"
-      ActiveSupport::Notifications.subscribe(key, &block)
+      ActiveSupport::Notifications.subscribe("#{event}.coach", &block)
     end
 
     def log_middleware_finish(event, start, finish)
@@ -89,11 +86,6 @@ module Coach
       serialized = RequestSerializer.new(event[:request]).serialize.
         merge(benchmark.stats).
         merge(event.slice(:response, :metadata))
-      if ActiveSupport::Notifications.notifier.listening?("coach.request")
-        ActiveSupport::Deprecation.warn("The 'coach.request' event has been renamed " \
-          "to 'request.coach' and the old name will be removed in a future version.")
-        ActiveSupport::Notifications.publish("coach.request", serialized)
-      end
       ActiveSupport::Notifications.publish("request.coach", serialized)
     end
   end


### PR DESCRIPTION
We deprecated this format in April 2018, so over one year later we can
safely remove it.