### PR TITLE
Improve docs around notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,17 @@ solution to Rails `process_action.action_controller` event emitted on controller
 The benchmarking data includes information on how long each middleware took to process,
 along with the total duration of the chain.
 
+For coach to emit `request.coach` events, it first needs to be subscribed to handler/middleware events:
+
+```ruby
+Coach::Notifications.subscribe!
+
+# Now you can subscribe to and use request.coach events, e.g.
+ActiveSupport::Notifications.subscribe("request.coach") do |_, event|
+  Rails.logger.info(event)
+end
+```
+
 You can add additional metadata to the notifications published by Coach by calling the
 `log_metadata` method from inside your Coach middlewares.
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ end
 You can add additional metadata to the notifications published by Coach by calling the
 `log_metadata` method from inside your Coach middlewares.
 
-```
+```ruby
 class Tracking < Coach::Middleware
   requires :user
 

--- a/lib/coach/notifications.rb
+++ b/lib/coach/notifications.rb
@@ -10,7 +10,7 @@ module Coach
   # Notifications is used to coordinate the listening and aggregation of these middleware
   # notifications, while RequestEvent processes the published data.
   #
-  # Once a request has completed, Notifications will emit a 'requst.coach' with
+  # Once a request has completed, Notifications will emit a 'request.coach' event with
   # aggregated request data.
   class Notifications
     # Begin processing/emitting 'request.coach's


### PR DESCRIPTION
It's currently not obvious that you need to `Coach::Notifications.subscribe!` to get `request.coach` events! ✨ 