### PR TITLE
RequestSerializer: include Content-Type and Content-Length headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 No unreleased changes.
 
+# 2.1.0 / 2019-11-14
+
+* [#79](https://github.com/gocardless/coach/pull/79) RequestSerializer will now
+  return the 'http_content_type' and 'http_content_length' filtered headers.
+
+* [#75](https://github.com/gocardless/coach/pull/75) Documentation update.
+
 # 2.0.0 / 2019-06-13
 
 ## Breaking changes


### PR DESCRIPTION
RequestSerializer returns, among other things, the filtered http headers
of the handled request, that is: all the HTTP_* headers normally
provided by Rack with a filtering rule applied (this is useful if you
want to e.g. mask or transform the content of some headers).

Among the request headers injected by Rack into the request environment
there are two notable exceptions to the 'HTTP_' rule: both CONTENT_TYPE
and CONTENT_LENGTH are not prefixed with 'HTTP_'. (more on this on the
Rack SPEC doc [0] and the lint file [1]).

This pull request changes the headers filtering logic to take both
CONTENT_TYPE and CONTENT_LENGTH into account. RequestSerializer will now
return 'http_content_type' and 'http_content_length'.

As far as I can tell this is a backward-compatible change as we're just
returning a new pair of headers. No filtering rule should be broken by
this change as such rules are only applied to the filtered headers.

[0] https://rubydoc.info/github/rack/rack/master/file/SPEC
[1] https://github.com/rack/rack/blob/master/lib/rack/lint.rb