### PR TITLE
[RFC] Support passing blocks to middleware

### DIFF
--- a/lib/coach/middleware.rb
+++ b/lib/coach/middleware.rb
@@ -4,8 +4,8 @@ require "coach/middleware_item"
 
 module Coach
   class Middleware
-    def self.uses(middleware, config = {})
-      middleware_dependencies << MiddlewareItem.new(middleware, config)
+    def self.uses(middleware, config = {}, &block)
+      middleware_dependencies << MiddlewareItem.new(middleware, config, &block)
     end
 
     def self.middleware_dependencies

--- a/lib/coach/middleware_item.rb
+++ b/lib/coach/middleware_item.rb
@@ -10,13 +10,15 @@ module Coach
     def initialize(middleware, config = {})
       @middleware = middleware
       @config_value = config
+      @block = Proc.new if block_given?
     end
 
     def build_middleware(context, successor)
       @middleware.
         new(context,
             successor&.instrument,
-            config)
+            config,
+            &@block)
     end
 
     # Runs validation against the middleware chain, raising if any unmet dependencies are


### PR DESCRIPTION
For some middleware, it might make sense to accept a block rather than a hash (or a hash where one of the keys is a block). For example:

```
class Throttle < Coach::Middleware
  def initialize(context, next_middleware, config = {}, &block)
    @throttle = Rack::Attack::Throttle.new(..., &block)
    super
  end
end
```

This commit modifies the internals of Coach to pass that block through the chain to the middleware. No specs yet, this is just an experiment.