### PR TITLE
Use commander-rb option parser instead of slop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 No unreleased changes.
 
+# 2.2.1 / 2020-02-06
+
+* [#85](https://github.com/gocardless/coach/pull/85) Uses [commander](https://github.com/commander-rb/commander) for CLI option parsing
+
 # 2.2.0 / 2020-01-08
 
 * [#68](https://github.com/gocardless/coach/pull/68) Add `coach` CLI and add
@@ -135,4 +139,3 @@ consistent with other libraries. The previous names will work for now, but will 
 
 Initial public release. This library is in beta until it hits 1.0, so backwards
 incompatible changes may be made in minor version releases.
-

--- a/bin/coach
+++ b/bin/coach
@@ -1,57 +1,95 @@
 #!/usr/bin/env ruby
 
-require "slop"
 require "coach/cli/provider_finder"
+require "commander"
 
-begin
-  require File.join(Dir.pwd, "config/environment")
-rescue LoadError
-  puts <<~EOS
-    Could not load your Rails app
-    =============================
+module Coach
+  class CLI
+    extend Commander::Methods
 
-    Currently the coach CLI assumes you have a config/environment.rb file that
-    we can load. We believe this is true of Rails apps in general.
+    class << self
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def run
+        program :version, Coach::VERSION
+        program :description,
+                "Coach's CLI to help understand the provide/require graph made up of " \
+                "all the middleware chains you've built using Coach.\n" \
+                "  More information at: https://github.com/gocardless/coach#coach-cli."
+        program :help_formatter, :compact
 
-    Please raise an issue if that's not the case!
+        never_trace!
 
-    https://github.com/gocardless/coach/issues
-  EOS
-  exit 1
-end
+        command "find-provider" do |c|
+          c.syntax = "bundle exec coach find-provider"
+          c.description =
+            "Given the name of a Coach middleware and a value that it requires, it " \
+            "outputs the name of the middleware that provides it."
 
-Slop.parse do
-  command "find-provider" do
-    run do |_, args|
-      middleware_name, value_name = *args
-      raise ArgumentError, "middleware_name and value_name required" unless middleware_name && value_name
+          c.action do |args, _|
+            load_config_environment
 
-      result = Coach::Cli::ProviderFinder.new(args[0], args[1]).find_provider
+            middleware_name, value_name = *args
+            raise ArgumentError, "middleware_name and value_name required" unless middleware_name && value_name
 
-      puts "Value `#{value_name}` is provided to `#{middleware_name}` by:\n\n"
-      puts result.to_a.join("\n")
-    end
-  end
+            result = Coach::Cli::ProviderFinder.new(args[0], args[1]).find_provider
 
-  command "find-chain" do
-    run do |_, args|
-      middleware_name, value_name = *args
-      raise ArgumentError, "middleware_name and value_name required" unless middleware_name && value_name
+            puts "Value `#{value_name}` is provided to `#{middleware_name}` by:\n\n"
+            puts result.to_a.join("\n")
+          end
+        end
 
-      chains = Coach::Cli::ProviderFinder.new(middleware_name, value_name).find_chain
+        command "find-chain" do |c|
+          c.syntax = "bundle exec coach find-chain"
+          c.description =
+            "Given the name of a Coach middleware and a value it requires, " \
+            "it outputs the chains of middleware between the specified middleware " \
+            "and the one that provides the required value."
 
-      if chains.size > 1
-        puts "Value `#{value_name}` is provided to `#{middleware_name}` " \
-          "by multiple middleware chains:\n\n"
-      else
-        puts "Value `#{value_name}` is provided to `#{middleware_name}` by:\n\n"
+          c.action do |args, _|
+            load_config_environment
+
+            middleware_name, value_name = *args
+            raise ArgumentError, "middleware_name and value_name required" unless middleware_name && value_name
+
+            chains = Coach::Cli::ProviderFinder.new(middleware_name, value_name).find_chain
+
+            if chains.size > 1
+              puts "Value `#{value_name}` is provided to `#{middleware_name}` " \
+                "by multiple middleware chains:\n\n"
+            else
+              puts "Value `#{value_name}` is provided to `#{middleware_name}` by:\n\n"
+            end
+
+            formatted_chains = chains.map do |chain|
+              chain.join(" -> ")
+            end.join("\n---\n")
+
+            puts formatted_chains
+          end
+        end
+
+        run!
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-      formatted_chains = chains.map do |chain|
-        chain.join(" -> ")
-      end.join("\n---\n")
+      def load_config_environment
+        require File.join(Dir.pwd, "config/environment")
+      rescue LoadError
+        puts <<~ERR
+          Could not load your Rails app
+          =============================
 
-      puts formatted_chains
+          Currently the coach CLI assumes you have a config/environment.rb file that
+          we can load. We believe this is true of Rails apps in general.
+
+          Please raise an issue if that's not the case!
+
+          https://github.com/gocardless/coach/issues
+        ERR
+        exit 1
+      end
     end
   end
 end
+
+Coach::CLI.run

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -21,9 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack", ">= 4.2"
   spec.add_dependency "activesupport", ">= 4.2"
-  # TODO: Find another CLI parser that supports subcommands
-  # Slop v4 got rid of them :(
-  spec.add_dependency "slop", "~> 3.6"
+  spec.add_dependency "commander", "~> 4.5"
 
   spec.add_development_dependency "gc_ruboconfig", "= 2.9.0"
   spec.add_development_dependency "pry", "~> 0.10"

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coach
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end


### PR DESCRIPTION
commander has support for subcommands, which we need on other projects, hence good to standardise on an option parser.