### PR TITLE
Fix missing require

### DIFF
--- a/bin/coach
+++ b/bin/coach
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "coach/cli/provider_finder"
+require "coach/version"
 require "commander"
 
 module Coach

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coach
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/spec/lib/coach/cli/provider_finder_spec.rb
+++ b/spec/lib/coach/cli/provider_finder_spec.rb
@@ -201,7 +201,7 @@ describe Coach::Cli::ProviderFinder do
         expect(provider_finder.find_chain).
           to eq([
             %w[FirstProvidingMiddleware FirstIntermediateMiddleware RequiringMiddleware],
-            %w[SecondProvidingMiddleware SecondIntermediateMiddleware RequiringMiddleware], # rubocop:disable Metrics/LineLength
+            %w[SecondProvidingMiddleware SecondIntermediateMiddleware RequiringMiddleware], # rubocop:disable Layout/LineLength
           ].to_set)
       end
     end


### PR DESCRIPTION
otherwise, `bundle exec coach` fails with:

```
bundler: failed to load command: coach (/Users/stevej/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bin/coach)
NameError: uninitialized constant Coach::VERSION
```