### PR TITLE
Record status:0 and exception metadata when exception occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-No unreleased changes.
+* [#90](https://github.com/gocardless/coach/pull/90) Instrument status `0` instead of `500` when Coach::Handler catches an exception
 
 # 2.2.1 / 2020-02-06
 

--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/object/try"
 
 module Coach
   class Handler
-    STATUS_CODE_FOR_EXCEPTIONS = 500
+    STATUS_CODE_FOR_EXCEPTIONS = 0
 
     def initialize(middleware, config = {})
       @root_item = MiddlewareItem.new(middleware, config)
@@ -34,6 +34,8 @@ module Coach
       instrument("finish_handler.coach", event) do
         begin
           response = chain.instrument.call
+        rescue StandardError => e
+          raise
         ensure
           # We want to populate the response and metadata fields after the middleware
           # chain has completed so that the end of the instrumentation can see them. The
@@ -43,7 +45,10 @@ module Coach
           # This way, the last finish_handler.coach event will have all the details.
           status = response.try(:first) || STATUS_CODE_FOR_EXCEPTIONS
           event.merge!(
-            response: { status: status },
+            response: {
+              status: status,
+              exception: e,
+            }.compact,
             metadata: context.fetch(:_metadata, {}),
           )
         end

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -85,10 +85,10 @@ describe Coach::Handler do
 
         before { terminal_middleware.uses(middleware_a, callback: explosive_action) }
 
-        it "captures the error event with the metadata" do
+        it "captures the error event with the metadata and nil status" do
           expect(coach_events).
             to include(["finish_handler.coach", hash_including(
-              response: { status: 500 },
+              response: { status: 0, exception: instance_of(RuntimeError) },
               metadata: { A: true },
             )])
         end


### PR DESCRIPTION
Coach makes an assumption that an unhandled exception deep in the
    middleware chain is going to render a HTTP 500 response. However, how
    your application handles that exception will ultimately affect the
    response. In Rails applications it is common to have a multitude of Rack
    middleware which do some additional response handling, in particular
    catching certain classes of exception and remapping them. Coach
    currently just bubbles the exception back to Rails' router, which
    handles the exception in it's own way.

So, if you were using `finish_handler.coach` events in logs to check
    response states, you might be misled i3nto thinking that a 500 error was
    issued by the application when in fact it had been remapped into
    something else by a Rack middleware further up the stack.

Therefore, this assumption is faulty, and I believe instead we should
    explicitly mark the status as `0` under these circumstances (`nil` is an
    alternative but not an integer which might cause havoc with other code
    handlers). We also attach the exception itself which can be inspected by
    other layers.