### PR TITLE
MIXP-1331 improving timeout observability

### DIFF
--- a/lib/coach/middleware.rb
+++ b/lib/coach/middleware.rb
@@ -46,7 +46,8 @@ module Coach
       requirements.include?(provision)
     end
 
-    attr_reader :next_middleware, :config
+    attr_reader :_context, :next_middleware, :config
+    alias_method :context, :_context
 
     # Middleware gets access to a shared context, which is populated by other
     # middleware futher up the stack, a reference to the next middleware in

--- a/lib/coach/version.rb
+++ b/lib/coach/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coach
-  VERSION = "2.3.0"
+  VERSION = "2.3.1"
 end

--- a/spec/lib/coach/middleware_spec.rb
+++ b/spec/lib/coach/middleware_spec.rb
@@ -76,4 +76,19 @@ describe Coach::Middleware do
       end
     end
   end
+
+  describe "#attributes" do
+    before { middleware_class.provides(:foo) }
+
+    context "context is initialized and assigned" do
+      it "checks alias of context to _context" do
+        expect(middleware_obj.context).to eq(context_)
+      end
+
+      it "assigns to context" do
+        expect { middleware_obj.provide(foo: "bar") }.
+          to change(middleware_obj, :context).from({}).to(foo: "bar")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#Why

Context obj is needed by middleware in application for various purposes such as logging

# What 

Context is being exposed as read only attribute so that coach middleware can use it for purposes like logging which will be used in MIXP-1331