### PR TITLE
Add support for route names rather than classes in Handler and Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+* [#105](https://github.com/gocardless/coach/pull/105) Add support for module/class names to be
+  passed to `Handler.new` and `Router#draw` to allow routes to be defined without loading the routes
+  constants, which makes using Zeitwerk much easier.
+
 # 2.3.0 / 2020-04-29
 
 * [#90](https://github.com/gocardless/coach/pull/90) Instrument status `0` instead of `500` when Coach::Handler catches an exception

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,10 @@ require "pry"
 require "coach"
 require "coach/rspec"
 
+Dir[Pathname(__FILE__).dirname.join("support", "**", "*.rb")].
+  sort.
+  each { |path| require path }
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/routes.rb
+++ b/spec/support/routes.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Routes
+  module Thing
+    class Index < Coach::Middleware
+      def call
+        [200, {}, []]
+      end
+    end
+
+    class Show < Coach::Middleware
+      def call
+        [200, {}, []]
+      end
+    end
+
+    class Create < Coach::Middleware
+      def call
+        [200, {}, []]
+      end
+    end
+
+    class Update < Coach::Middleware
+      def call
+        [200, {}, []]
+      end
+    end
+
+    class Destroy < Coach::Middleware
+      def call
+        [200, {}, []]
+      end
+    end
+
+    class Refund < Coach::Middleware
+      def call
+        [200, {}, []]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows us to support Zeitwerk-using Rails apps, where we can't autoload safely during app boot.

I've added builds against newer Rubies and Rails here. It seems like Coach is not compatible with Ruby 3, but I don't think that should block shipping this. We should add support for Ruby 3.0 (and probably drop support for EOL'd Rubies) in a breaking change - see #103 