### PR TITLE
Get the tests to run under Ruby 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,36 @@ jobs:
         environment:
           - RAILS_VERSION=4.2.10
     steps: *steps
+  build-ruby26-rails515:
+    docker:
+      - image: ruby:2.6
+        environment:
+          - RAILS_VERSION=5.1.5
+    steps: *steps
+  build-ruby27-rails515:
+    docker:
+      - image: ruby:2.7
+        environment:
+          - RAILS_VERSION=5.1.5
+    steps: *steps
+  build-ruby27-rails604:
+    docker:
+      - image: ruby:2.7
+        environment:
+          - RAILS_VERSION=6.0.4
+    steps: *steps
+  build-ruby27-rails614:
+    docker:
+      - image: ruby:2.7
+        environment:
+          - RAILS_VERSION=6.1.4
+    steps: *steps
+  build-ruby30-rails614:
+    docker:
+      - image: ruby:3.0
+        environment:
+          - RAILS_VERSION=6.1.4
+    steps: *steps
 
 workflows:
   version: 2
@@ -66,3 +96,8 @@ workflows:
       - build-ruby24-rails4210
       - build-ruby25-rails515
       - build-ruby25-rails4210
+      - build-ruby26-rails515
+      - build-ruby27-rails515
+      - build-ruby27-rails604
+      - build-ruby27-rails614
+      - build-ruby30-rails614

--- a/coach.gemspec
+++ b/coach.gemspec
@@ -28,4 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.0"
+  # 1.12 removed support for Ruby 2.4, which we still support. We can remove this pin
+  # when we drop support for Ruby 2.4.
+  spec.add_development_dependency "rubocop", "< 1.12"
 end

--- a/lib/coach/rspec.rb
+++ b/lib/coach/rspec.rb
@@ -15,7 +15,7 @@ def build_middleware(name)
 
     def call
       config[:callback].call if config.include?(:callback)
-      log_metadata(Hash[name.to_sym, true])
+      log_metadata(**{ name.to_sym => true })
 
       response = [name + config.except(:callback).inspect.to_s]
 


### PR DESCRIPTION
The only change required was to be more careful about kwargs/hash
arguments in the rspec helper.