### PR TITLE
Fix middleware constant resolution in Rails 7

### DIFF
--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -93,7 +93,11 @@ module Coach
     end
 
     def middleware
-      @middleware ||= ActiveSupport::Dependencies.constantize(name)
+      @middleware ||= if ActiveSupport::Dependencies.respond_to?(:constantize)
+                        ActiveSupport::Dependencies.constantize(name)
+                      else
+                        name.constantize
+                      end
     end
 
     # Remove middleware that have been included multiple times with the same


### PR DESCRIPTION
Previously we relied on `ActiveSupport::Dependencies.constantize` to load the name of the module this method is removed in rails 7 due to the classic autoloader being removed -
see https://github.com/rails/rails/pull/43058 for details.

Instead we can simply call `name.constantize`