### PR TITLE
Use inflector constantize method in handler

### DIFF
--- a/lib/coach/handler.rb
+++ b/lib/coach/handler.rb
@@ -93,11 +93,7 @@ module Coach
     end
 
     def middleware
-      @middleware ||= if ActiveSupport::Dependencies.respond_to?(:constantize)
-                        ActiveSupport::Dependencies.constantize(name)
-                      else
-                        name.constantize
-                      end
+      @middleware ||= ActiveSupport::Inflector.constantize(name)
     end
 
     # Remove middleware that have been included multiple times with the same

--- a/spec/lib/coach/handler_spec.rb
+++ b/spec/lib/coach/handler_spec.rb
@@ -47,14 +47,14 @@ describe Coach::Handler do
         subject(:handler) { described_class.new(terminal_middleware.name, handler: true) }
 
         before do
-          allow(ActiveSupport::Dependencies).to receive(:constantize).and_call_original
-          allow(ActiveSupport::Dependencies).to receive(:constantize).
+          allow(ActiveSupport::Inflector).to receive(:constantize).and_call_original
+          allow(ActiveSupport::Inflector).to receive(:constantize).
             with(terminal_middleware.name).
             and_return(terminal_middleware)
         end
 
         it "does not load the route when initialized" do
-          expect(ActiveSupport::Dependencies).
+          expect(ActiveSupport::Inflector).
             to_not receive(:constantize).with(terminal_middleware.name)
 
           handler

--- a/spec/lib/coach/router_spec.rb
+++ b/spec/lib/coach/router_spec.rb
@@ -86,10 +86,10 @@ describe Coach::Router do
         let(:resource_routes) { Routes::Thing.name }
 
         before do
-          allow(ActiveSupport::Dependencies).to receive(:constantize).and_call_original
+          allow(ActiveSupport::Inflector).to receive(:constantize).and_call_original
 
           routes.each do |class_name|
-            allow(ActiveSupport::Dependencies).to receive(:constantize).
+            allow(ActiveSupport::Inflector).to receive(:constantize).
               with("Routes::Thing::#{class_name}").
               and_return(Routes::Thing.const_get(class_name))
           end


### PR DESCRIPTION
The constantize method in `ActiveSupport::Dependencies` has been removed and the method in the String class just forwards to the inflector implementation. This change calls the inflector implementation directly to reduce complexity