### PR TITLE
Add OpenTelemetry support to coach middleware and handlers

### DIFF
--- a/coach.gemspec
+++ b/coach.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "actionpack", ">= 4.2"
   spec.add_dependency "activesupport", ">= 4.2"
   spec.add_dependency "commander", "~> 4.5"
+  spec.add_dependency "opentelemetry-sdk"
 
   spec.add_development_dependency "gc_ruboconfig", "~> 2.18.0"
   spec.add_development_dependency "pry", "~> 0.10"
@@ -29,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.2"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.0"
   spec.add_development_dependency "rubocop", "~> 1.12"
+  spec.add_development_dependency "rack", "~> 2.2"
 end

--- a/spec/lib/coach/notifications_spec.rb
+++ b/spec/lib/coach/notifications_spec.rb
@@ -5,6 +5,7 @@ require "coach/notifications"
 
 describe Coach::Notifications do
   subject(:notifications) { described_class.instance }
+  let(:request) { Rack::MockRequest.env_for("https://example.com:8080/full/path?query=string", {"REMOTE_ADDR" => "10.10.10.10"}) }
 
   before do
     described_class.unsubscribe!
@@ -47,12 +48,12 @@ describe Coach::Notifications do
     end
 
     it "will now send request.coach" do
-      handler.call({})
+      handler.call(request)
       expect(middleware_event).to_not be_nil
     end
 
     describe "request.coach event" do
-      before { handler.call({}) }
+      before { handler.call(request) }
 
       it "contains all middleware that have been run" do
         middleware_names = middleware_event[:chain].map { |item| item[:name] }
@@ -70,13 +71,13 @@ describe Coach::Notifications do
     it "disables any prior subscriptions" do
       notifications.subscribe!
 
-      handler.call({})
+      handler.call(request)
       expect(events.count { |(name, _)| name == "request.coach" }).
         to eq(1)
 
       notifications.unsubscribe!
 
-      handler.call({})
+      handler.call(request)
       expect(events.count { |(name, _)| name == "request.coach" }).
         to eq(1)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,22 @@
 
 require "rspec/its"
 require "pry"
+require "rack"
 require "coach"
 require "coach/rspec"
+require "opentelemetry/sdk"
 
 Dir[Pathname(__FILE__).dirname.join("support", "**", "*.rb")].
   sort.
   each { |path| require path }
+
+
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+SPAN_PROCESSOR = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor SPAN_PROCESSOR
+end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
This adds OpenTelemetry tracing support to Coach. In normal operation is produces two types of spans:

- A span around the handler which includes most of the `http` spec attributes.
- A span around each middleware.

It is designed to replace the standard `Rack` auto-instrumentation library in GC environments.
