### PR TITLE
Fix rspec deprecation warnings

### DIFF
--- a/spec/lib/coach/middleware_validator_spec.rb
+++ b/spec/lib/coach/middleware_validator_spec.rb
@@ -4,8 +4,6 @@ require "spec_helper"
 require "coach/middleware_validator"
 
 describe Coach::MiddlewareValidator do
-  subject(:validator) { described_class.new(head_middleware, already_provided) }
-
   let(:head_middleware) { build_middleware("Head") }
   let(:already_provided) { [] }
 
@@ -22,7 +20,7 @@ describe Coach::MiddlewareValidator do
   end
 
   describe "#validated_provides!" do
-    subject { -> { validator.validated_provides! } }
+    subject(:validator) { -> { described_class.new(head_middleware, already_provided).validated_provides! } }
 
     context "with satisfied requires" do
       context "one level deep" do
@@ -60,7 +58,9 @@ describe Coach::MiddlewareValidator do
       context "at terminal" do
         before { head_middleware.requires :a, :c }
 
-        it { is_expected.to raise_exception(/missing \[:a, :c\]/) }
+        it "raises an exception" do
+          expect { validator.call }.to raise_exception(/missing \[:a, :c\]/)
+        end
       end
 
       context "from unordered middleware" do
@@ -69,7 +69,9 @@ describe Coach::MiddlewareValidator do
           middleware_b.provides :b
         end
 
-        it { is_expected.to raise_exception(/missing \[:b\]/) }
+        it "raises an exception" do
+          expect { validator.call }.to raise_exception(/missing \[:b\]/)
+        end
       end
     end
   end


### PR DESCRIPTION
These tests were generating warnings:

    The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise Exception with message matching /missing \[:a, :c\]/` not `expect(value).to raise Exception with message matching /missing \[:a, :c\]/`

    The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise Exception with message matching /missing \[:b\]/` not `expect(value).to raise Exception with message matching /missing \[:b\]/`